### PR TITLE
Authorization with pundit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "rails", "~> 5.2.1"
 gem "sass-rails", "~> 5.0"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
+gem "pundit", "~> 2.0.0"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.12.0)
+    pundit (2.0.0)
+      activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -365,6 +367,7 @@ DEPENDENCIES
   pry
   pry-rails
   puma (~> 3.11)
+  pundit (~> 2.0.0)
   rails (~> 5.2.1)
   rspec-rails (~> 3.5)
   rubocop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   rescue_from ActiveRecord::RecordInvalid do |exception|
     Rails.logger.error(exception.message)
 
@@ -14,5 +18,11 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(*)
     new_partner_session_path
+  end
+
+  private
+
+  def user_not_authorized
+    redirect_to(request.referrer || root_path, notice: "You are not authorized to perform this action.")
   end
 end

--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -31,11 +31,17 @@ class PartnerRequestsController < ApplicationController
 
   def show
     @partner_request = PartnerRequest.find(params[:id])
+    authorize @partner_request
   end
 
   private
 
   def partner_request_params
     params.require(:partner_request).permit(:comments, items_attributes: Item.attribute_names.map(&:to_sym).push(:_destroy))
+  end
+
+  # NOTE(chaserx): the is required for pundit since our auth'd user is named `partner`
+  def pundit_user
+    current_partner
   end
 end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -6,6 +6,7 @@ class PartnersController < ApplicationController
   # GET /partners.json
   def index
     @partners = Partner.all
+    authorize @partners
   end
 
   # GET /partners/1
@@ -69,8 +70,10 @@ class PartnersController < ApplicationController
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # NOTE(chaserx): pundit let's us authorize partner specific actions here as a
+  #  convenience rather than in each of the partner specific methods
   def set_partner
-    @partner = Partner.find(params[:id])
+    @partner = authorize Partner.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
@@ -153,5 +156,10 @@ class PartnersController < ApplicationController
       :diaper_funding_source,
       documents: []
     )
+  end
+
+  # NOTE(chaserx): the is required for pundit since our auth'd user is named `partner`
+  def pundit_user
+    current_partner
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -1,0 +1,25 @@
+# Authorization for CRUD actions on Partner using Pundit
+#
+# Pundit relies on current_user
+#   see `pundit_user` method in partners_controller
+#
+# Partners can only affect their own records.
+# Later may want to admins authorization.
+class PartnerPolicy < ApplicationPolicy
+  def create?
+    true
+  end
+
+  def show?
+    record == user
+  end
+
+  def update?
+    record == user
+  end
+
+  # TODO(chaserx): I think we should prevent deletion until we add a soft delete
+  def destroy?
+    false
+  end
+end

--- a/app/policies/partner_request_policy.rb
+++ b/app/policies/partner_request_policy.rb
@@ -1,0 +1,19 @@
+# Authorization for limited CRUD actions on Partner Requests using Pundit
+#
+# Pundit relies on current_user
+#   see `pundit_user` method in partner_requests_controller
+#
+# Partners can only view and create their own records.
+class PartnerRequestPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def create?
+    record.partner == user
+  end
+
+  def show?
+    record.partner == user
+  end
+end

--- a/app/views/partner_requests/index.html.erb
+++ b/app/views/partner_requests/index.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav justify-content-end">
-    <%= link_to 'Organization', partner_path(@partner), class: 'btn btn-primary' %>
+    <%= link_to 'Organization', partner_path(current_partner), class: 'btn btn-primary' %>
     &nbsp
     <%= link_to 'Sign Out', destroy_partner_session_path, class: 'btn btn-warning', method: :delete %>
 </ul>

--- a/app/views/partner_requests/show.html.erb
+++ b/app/views/partner_requests/show.html.erb
@@ -1,3 +1,12 @@
+<ul class="nav justify-content-end">
+  <li class="nav-item">
+    <%= link_to 'Account', edit_partner_path(current_partner), class: 'nav-link' %>
+  </li>
+  <li class="nav-item">
+    <%= link_to 'Sign Out', destroy_partner_session_path, class: 'nav-link', method: :delete %>
+  </li>
+</ul>
+
 <h1>Thanks</h1>
 
 <% if @partner_request.errors.any? %>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -4,9 +4,8 @@
   </li>
 </ul>
 
-<p id="notice"><%= notice %></p>
-
 <div class="container">
+  <p id="notice"><%= notice %></p>
   <div class="actions">
     <% if @partner.verified? %>
       <%= link_to 'Request Diapers', partner_requests_path, class: 'btn btn-success' %>

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe PartnerRequestsController, type: :controller do
     end
   end
 
-  describe "GET #show" do
-    it "returns http success" do
-      @partner_request = create(:partner_request_with_items)
+  describe 'GET #show' do
+    it 'returns http success' do
+      @partner = create(:partner)
+      sign_in @partner
+      @partner_request = create(:partner_request_with_items, partner: @partner)
       get :show, params: { id: @partner_request.id }
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
### Description

We [discussed previously in slack](https://rubyforgood.slack.com/archives/C8VC5FLQ0/p1541168645024200) the need to protect the partners information through the use of some authorization scheme. 

This adds some light weight authorization via [Pundit](https://github.com/varvet/pundit). 

**Partners**:
no one: index, destroy
anyone is authorized to: new, create
restricted to the current_partner being equal to the requested partner for:  show, edit, update

**Partner Requests**:
restricted to the current_partner being equal to the requested partner for: new, create, index, show

### Type of change

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- RSpec tests have been slightly modified to allow for passing tests. 
- Human testing

