### PR TITLE
update seeds to match what's in diaperbase readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ If you're getting the error `PG::ConnectionBad: fe_sendauth: no password supplie
 ## Seed the database
 From the root of the app, run `bundle exec rails db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
 
+To login, use these default credentials provided in the seeds:
+
+    Verified Organization
+      Email: org_admin1@example.com
+      Password: password
+
+    Pending Organization
+      Email: user_1@example.com
+      Password: password
+
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require 'faker'
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #
@@ -5,6 +7,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
 puts "Creating partners..."
 puts "Adding an 'approved' partner."
 Partner.create(
@@ -18,14 +21,27 @@ Partner.create(
     zip_code: 62558,
     website: "http://pawneeindiana.com",
     zips_served: 62558,
-    executive_director_email: "leslie@example.com",
-    email: "leslie@example.com",
+    executive_director_email: "org_admin1@example.com",
+    email: "org_admin1@example.com",
     password: "password",
     partner_status: "Verified"
 )
+
 puts "Adding a generic 'pending' partner."
+pending_user_name = Faker::Name.name
 Partner.create(
-    email: "pending@example.com",
+    executive_director_name: pending_user_name,
+    program_contact_name: pending_user_name,
+    name: "County Diaper Bank",
+    address1: Faker::Address.street_address,
+    address2: "",
+    city: Faker::Address.city,
+    state: Faker::Address.state_abbr,
+    zip_code: Faker::Address.zip,
+    website: Faker::Internet.domain_name,
+    zips_served: Faker::Address.zip,
+    executive_director_email: "user1@example.com",
+    email: "user1@example.com",
     password: "password"
 )
 puts "Done creating partners."


### PR DESCRIPTION
Resolves #52 

### Description

This updates the email addresses in the seeds to match those outlined in [diaperbase](https://github.com/rubyforgood/diaper#login). 

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Documentation update

### How Has This Been Tested?

Tested locally by reseting the database.
