### PR TITLE
Updates ruby version to 2.5.3 in README, rubocop, and prod deploy files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_from: .rubocop_todo.yml
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5.1
+  TargetRubyVersion: 2.5.3
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the partner gets an email notification stating their pick up date and a pdf copy
 ## Development
 
 ### Ruby Version
-This app uses Ruby version 2.5.1, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
+This app uses Ruby version 2.5.3, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
 
 ### Database Configuration
 This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `partner_dev` and `partner_test`, respectively. This should all be handled with `bundle exec rails db:setup`.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -38,7 +38,7 @@ server "104.211.13.79", roles: %w{web app db}, primary: true,
 # Feel free to add new variables to customise your setup.
 
 set :rvm_type, :user
-set :rvm_ruby_version, "2.5.1"
+set :rvm_ruby_version, "2.5.3"
 # Custom SSH Options
 # ==================
 # You may pass any option but keep in mind that net/ssh understands a


### PR DESCRIPTION
### Description

I noticed in the README that the ruby version did not match what was in the Gemfile and .ruby-version file, so I updated it in the README, and the rubocop and prod deploy configs.

### Type of change

<!-- Please delete options that are not relevant. -->

* This change requires a documentation update
* Documentation update

### How Has This Been Tested?

Ran the existing test suite and rubocop - all green.
