### PR TITLE
Adding and updating controller and model specs, and related changes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem "chromedriver-helper"
   gem "email_spec"
+  gem "shoulda-matchers"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     shellany (0.0.1)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -373,6 +375,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
@@ -384,4 +387,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/app/models/partner_request.rb
+++ b/app/models/partner_request.rb
@@ -1,5 +1,5 @@
 class PartnerRequest < ApplicationRecord
-  belongs_to :partner, dependent: :destroy
+  belongs_to :partner
 
   has_many :items, dependent: :destroy
   accepts_nested_attributes_for :items, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -1,30 +1,56 @@
 require "rails_helper"
 
-RSpec.describe PartnerRequestsController, type: :controller do
-  login_partner
+describe PartnerRequestsController, type: :controller do
+  context "when authenticated" do
+    login_partner
 
-  describe "GET #new" do
-    it "returns http success" do
-      get :new
-      expect(response).to have_http_status(200)
+    describe "GET #new" do
+      it "returns http success" do
+        get :new
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe "POST #create" do
+      it "creates a new partner_request" do
+        expect do
+          post :create, params: { partner_request: attributes_for(:partner_request_with_items) }
+        end.to change(PartnerRequest, :count).by(1)
+      end
+    end
+
+    describe "GET #show" do
+      it "returns http success" do
+        @partner = create(:partner)
+        sign_in @partner
+        @partner_request = create(:partner_request_with_items, partner: @partner)
+        get :show, params: { id: @partner_request.id }
+        expect(response).to have_http_status(200)
+      end
     end
   end
 
-  describe "POST #create" do
-    it "creates a new partner_request" do
-      expect do
-        post :create, params: { partner_request: attributes_for(:partner_request_with_items) }
-      end.to change(PartnerRequest, :count).by(1)
-    end
-  end
+  context "when not authenticated" do
+    describe "GET #new" do
+      subject { get :new }
 
-  describe "GET #show" do
-    it "returns http success" do
-      @partner = create(:partner)
-      sign_in @partner
-      @partner_request = create(:partner_request_with_items, partner: @partner)
-      get :show, params: { id: @partner_request.id }
-      expect(response).to have_http_status(200)
+      it_behaves_like "user is not logged in"
+    end
+
+    describe "POST #create" do
+      it "does not create a new partner_request" do
+        expect do
+          post :create, params: { partner_request: attributes_for(:partner_request_with_items) }
+        end.to_not change(PartnerRequest, :count)
+      end
+    end
+
+    describe "GET #show" do
+      subject { get :show, params: { id: partner_request.id } }
+      let(:partner) { create(:partner) }
+      let(:partner_request) { create(:partner_request_with_items, partner: partner) }
+
+      it_behaves_like "user is not logged in"
     end
   end
 end

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -1,28 +1,69 @@
 require "rails_helper"
 
-RSpec.describe PartnersController, type: :controller do
-  login_partner
+describe PartnersController, type: :controller do
+  context "when authenticated" do
+    login_partner
 
-  describe "GET #new" do
-    it "returns http success" do
-      get :new
-      expect(response).to have_http_status(200)
+    describe "GET #new" do
+      it "returns http success" do
+        get :new
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe "GET #show" do
+      it "returns http success" do
+        get :show, params: { id: @partner.id }
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe "Get #approve" do
+      it "should redirect to partner" do
+        @partner = create(:partner)
+        get :approve, params: { partner_id: @partner.id }
+        expect(response).to redirect_to(@partner)
+      end
+    end
+
+    describe "Post #create" do
+      it "creates a new partner" do
+        expect do
+          post :create, params: { partner: attributes_for(:partner) }
+        end.to change(Partner, :count).by(0)
+      end
     end
   end
 
-  describe "Get #approve" do
-    it "should redirect to partner" do
-      @partner = create(:partner)
-      get :approve, params: { partner_id: @partner.id }
-      expect(response).to redirect_to(@partner)
-    end
-  end
+  context "when not authenticated" do
+    let(:partner) { create(:partner) }
 
-  describe "Post #create" do
-    it "creates a new partner" do
-      expect do
-        post :create, params: { partner: attributes_for(:partner) }
-      end.to change(Partner, :count).by(0)
+    describe "GET #new" do
+      subject { get :new }
+
+      it_behaves_like "user is not logged in"
+    end
+
+    describe "GET #show" do
+      subject { get :show, params: { id: partner.id } }
+
+      it_behaves_like "user is not logged in"
+    end
+
+    describe "Get #approve" do
+      subject { get :approve, params: { partner_id: partner.id } }
+
+      it_behaves_like "user is not logged in"
+    end
+
+    describe "Post #create" do
+      subject { post :create, params: { partner: attributes_for(:partner) } }
+
+      it_behaves_like "user is not logged in"
+
+      it "does not create a new partner" do
+        expect { subject }.to_not change(Partner, :count)
+      end
     end
   end
 end

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PartnersController, type: :controller do
   describe "Post #create" do
     it "creates a new partner" do
       expect do
-        post :create, params: { partner: FactoryBot.attributes_for(:partner) }
+        post :create, params: { partner: attributes_for(:partner) }
       end.to change(Partner, :count).by(0)
     end
   end

--- a/spec/models/partner_request_spec.rb
+++ b/spec/models/partner_request_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe PartnerRequest, type: :model do
+  it { is_expected.to have_many(:items).dependent(:destroy) }
+
+  it { is_expected.to validate_presence_of(:partner) }
+
   describe "a valid PartnerRequest" do
     it "requires a Partner" do
       expect(build_stubbed(:partner_request)).to be_valid

--- a/spec/models/partner_request_spec.rb
+++ b/spec/models/partner_request_spec.rb
@@ -16,4 +16,14 @@ RSpec.describe PartnerRequest, type: :model do
       expect(partner_request.formatted_items_hash(partner_request.items)).to eql(formatted_hash)
     end
   end
+
+  describe "a request without an item quantity" do
+    let(:partner_request) { build(:partner_request) }
+    let(:item) { build(:item, name: "test", quantity: nil, partner_request: partner_request) }
+    it "fails" do
+      partner_request.items << item
+      expect(partner_request.save).to be false
+      expect(partner_request.errors.messages[:"items.quantity"]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -16,7 +16,7 @@ describe Partner, type: :model do
   describe "#approve_me" do
     let(:partner) { create(:partner) }
     it "changes the partner status to Submitted" do
-      expect{partner.approve_me}.to change {partner.partner_status}.from("pending").to("Submitted")
+      expect { partner.approve_me }.to change { partner.partner_status }.from("pending").to("Submitted")
     end
 
     it "posts the diaper partner id" do

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -1,14 +1,28 @@
 require "rails_helper"
 
 describe Partner, type: :model do
-  it "make name required" do
-    partner = build(:partner, email: nil)
+  it { is_expected.to have_many(:partner_requests).dependent(:destroy) }
 
+  it { is_expected.to validate_presence_of(:email) }
+
+  it "is not valid without an email address" do
+    partner = build(:partner, email: nil)
     expect(partner).to_not be_valid
 
     partner.email = "partner@email.com"
-
     expect(partner).to be_valid
+  end
+
+  describe "#approve_me" do
+    let(:partner) { create(:partner) }
+    it "changes the partner status to Submitted" do
+      expect{partner.approve_me}.to change {partner.partner_status}.from("pending").to("Submitted")
+    end
+
+    it "posts the diaper partner id" do
+      expect(DiaperBankClient).to receive(:post).with(partner.diaper_partner_id)
+      partner.approve_me
+    end
   end
 
   describe "verified?" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
+require "shoulda/matchers"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
@@ -9,7 +10,12 @@ require "factory_bot"
 require "devise"
 require_relative "support/controller_macros"
 # Add additional requires below this line. Rails is not loaded until this point!
-
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -1,20 +1,6 @@
 require "rails_helper"
 
 describe "Partners Api Requests" do
-  #   describe 'GET "/api/v1/partners' do
-  #     it "returns all partners" do
-  #       partner = FactoryBot.create(:partner)
-
-  #       get api_v1_partners_path
-
-  #       expect(response).to have_http_status(:ok)
-
-  #       results = JSON.parse(response.body)
-  #       expect(results.size).to eq 1
-  #       expect(results[0]["diaper_partner_id"]).to eq(partner.id)
-  #     end
-  #   end
-
   describe "GET /api/v1/partners/1" do
     let(:partner) { create(:partner) }
 

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,8 +2,8 @@ module ControllerMacros
   def login_partner
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:partner]
-      partner = create(:partner)
-      sign_in partner
+      @partner = create(:partner)
+      sign_in @partner
     end
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,7 +2,7 @@ module ControllerMacros
   def login_partner
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:partner]
-      partner = FactoryBot.create(:partner)
+      partner = create(:partner)
       sign_in partner
     end
   end

--- a/spec/support/shared_examples/user_not_logged_in.rb
+++ b/spec/support/shared_examples/user_not_logged_in.rb
@@ -1,0 +1,6 @@
+shared_examples_for "user is not logged in" do
+  it "returns a 302 redirect" do
+    subject
+    expect(response).to have_http_status(302)
+  end
+end


### PR DESCRIPTION
### Description

Adding and updating (some refactoring) controller and model specs as outlined below (and some as requested in #51 ).  Also adds a shared example, adds [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers), and some other minor related changes as detailed below.

**NOTE:** I didn't want to add or refactor too many at once before getting feedback.

### Type of change

* Adds and updates PartnerRequests and Partners controller specs
* Adds a shared example for when users are not logged in
* Updates `rails_helper` configs so shared examples can be used in specs
* Adds and updates PartnerRequest and Partner model specs
* Adds `shoulda-matchers` gem and configs
* Removes explicit calls to `FactoryBot`
* Removes `dependent: :destroy` from `belongs_to :partner` in PartnerRequest model (see [SO](https://stackoverflow.com/a/34625321/3557284))
* Updates `partner` to `@partner` in `controller_macros.rb` so it can be referenced in specs
* Remove commented out spec
* Remove explicit calls to `Rspec`

### How Has This Been Tested?

Mostly adding and updating specs - all specs are passing and rubocop is green.

### Question

This spec in PartnersController

```ruby
    describe "Post #create" do
      it "creates a new partner" do
        expect do
          post :create, params: { partner: attributes_for(:partner) }
        end.to change(Partner, :count).by(0)
      end
```

says that it creates a new partner, but then the spec says that it changes the Partner count by 0.  I'm not 100% familiar with this project yet, but I thought this spec seemed incorrect.  Thanks.

