### PR TITLE
Only Show Active Items in Partner Request Form

### DIFF
--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -8,6 +8,7 @@ class PartnerRequestsController < ApplicationController
 
   def new
     @partner_request = PartnerRequest.new
+    @valid_items = DiaperBankClient.get(current_partner.diaper_bank_id)
     @partner_request.items.build # required to render the empty items form
   end
 

--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -8,7 +8,7 @@ class PartnerRequestsController < ApplicationController
 
   def new
     @partner_request = PartnerRequest.new
-    @valid_items = DiaperBankClient.get(current_partner.diaper_bank_id)
+    @valid_items = DiaperBankClient.get_available_items(current_partner.diaper_bank_id)
     @partner_request.items.build # required to render the empty items form
   end
 

--- a/app/services/diaper_bank_client.rb
+++ b/app/services/diaper_bank_client.rb
@@ -12,17 +12,22 @@ module DiaperBankClient
     response.body
   end
 
-  def self.get(id)
-    return if Rails.env != "production"
+  def self.get_available_items(diaper_bank_id)
+    return unless Rails.env.production?
 
-    uri = URI(ENV["DIAPERBANK_PARTNER_REQUEST_URL"] + "/#{id}")
-    req = Net::HTTP::Get.new(uri, "Content-Type" => "application/json")
+    uri = URI(ENV["DIAPERBANK_PARTNER_REQUEST_URL"] + "/#{diaper_bank_id}")
+    req = Net::HTTP::Get.new(uri)
 
     req["Content-Type"] = "application/json"
-    req["X-Api-Key"] = ENV["PARTNER_KEY"]
+    req["X-Api-Key"] = ENV["DIAPERBANK_KEY"]
 
     response = https(uri).request(req)
-    JSON.parse(response.body)
+
+    if response.code.to_i == 200
+      JSON.parse(response.body)
+    else
+      []
+    end
   end
 
   def self.request_submission_post(partner_request_id)

--- a/app/services/diaper_bank_client.rb
+++ b/app/services/diaper_bank_client.rb
@@ -22,7 +22,7 @@ module DiaperBankClient
     req["X-Api-Key"] = ENV["PARTNER_KEY"]
 
     response = https(uri).request(req)
-    response.body
+    JSON.parse(response.body)
   end
 
   def self.request_submission_post(partner_request_id)

--- a/app/services/diaper_bank_client.rb
+++ b/app/services/diaper_bank_client.rb
@@ -12,6 +12,19 @@ module DiaperBankClient
     response.body
   end
 
+  def self.get(id)
+    return if Rails.env != "production"
+
+    uri = URI(ENV["DIAPERBANK_PARTNER_REQUEST_URL"] + "/#{id}")
+    req = Net::HTTP::Get.new(uri, "Content-Type" => "application/json")
+
+    req["Content-Type"] = "application/json"
+    req["X-Api-Key"] = ENV["PARTNER_KEY"]
+
+    response = https(uri).request(req)
+    response.body
+  end
+
   def self.request_submission_post(partner_request_id)
     return unless Rails.env.production?
     return unless PartnerRequest.exists?(partner_request_id)

--- a/app/views/partner_requests/_item.html.erb
+++ b/app/views/partner_requests/_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= form.select :name, POSSIBLE_ITEMS.invert.collect, include_blank: 'Select an item' %></td>
+  <td><%= form.select :name, POSSIBLE_ITEMS.slice(*@valid_items).invert.collect, include_blank: 'Select an item' %></td>
   <td><%= form.number_field :quantity, label: false, step: 1, min: 1 %></td>
   <td>
     <%= form.hidden_field :_destroy, as: :hidden %>

--- a/app/views/partner_requests/new.html.erb
+++ b/app/views/partner_requests/new.html.erb
@@ -42,6 +42,7 @@
   <hr>
 
   <div class="actions">
+    <!-- TODO(chaserx): we should add some js to prevent submission if the items selected are the blank option or any item has an empty quantity -->
     <%= form.submit("Submit Diaper Request", class: "btn btn-primary") %> <%= link_to "Cancel Request", partner_requests_path, class: "btn btn-danger" %>
   </div>
 <% end %>


### PR DESCRIPTION
Resolves #63 

### Description

This change attempts to resolve #63. We've added a call to the diaper app in a corresponding PR (https://github.com/rubyforgood/diaper/pull/658) to retrieve the list of items for the given organization for the partner. 

### Type of Change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

* Tested locally in browser. 

Ultimately, what I'd like to see eventually are some tests of the ( DiaperBankClient itself and perhaps some fake in place for diaper app for some integration style tests. 

### Screenshots

![dynamic_items 2018-12-10 22_44_09](https://user-images.githubusercontent.com/7292/49778326-acf6fe80-fcd2-11e8-82a6-2a140a00fea9.gif)
