### PR TITLE
Allow specifying database hostname via PG_HOST env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ PG_PASSWORD=password
 ```
 If you're getting the error `PG::ConnectionBad: fe_sendauth: no password supplied`, it's because you have probably not done this.
 
+Optionally, you may add the following line to your `.env`
+file, which allows for specifying a database host other
+than the default of `localhost`:
+```
+PG_HOST=hostname
+```
+
 ## Seed the database
 From the root of the app, run `bundle exec rails db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: <%= ENV.fetch 'PG_HOST', 'localhost' %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV['PG_USERNAME'] %> # postgres
   password: <%= ENV['PG_PASSWORD'] %> # io


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes ("bundle exec rspec")
- Title include "WIP" if work is in progress.

-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

Include anything else we should know about. -->

I was unable to setup my development environment since logging in without a specified hostname on my system with the database as configured results in an authentication failure. This change allows for the default of `localhost` to remain the same, but for the option to change the hostname as needed. (This pattern is the same as that used for the `diaper` app, so it should likely feel familiar here.)

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update
* Documentation update

(This is a minor config change, and the README has been updated to reflect it.)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

One test is currently failing for me, but it seems to be a case where a prior test is not cleaning up after itself properly (or perhaps a prior run of this test). I'll look at that later, but it's an unrelated issue to this.
