### PR TITLE
replaces preheader with 1st line of email body

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -332,7 +332,7 @@
       <div class="content">
 
         <!-- START CENTERED WHITE CONTAINER -->
-        <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
+        <span class="preheader">You've been invited to become a partner organization.</span>
         <table role="presentation" class="main">
 
           <!-- START MAIN CONTENT AREA -->


### PR DESCRIPTION
Found while resolving https://github.com/rubyforgood/partner/issues/77

See also: https://github.com/rubyforgood/diaper/pull/708

### Description

Our community partner PDX Diaperbank reported a minor bug where placeholder text was visible to email recipients. This small change uses their suggestion to replace that placeholder text in the preheaders with the first line from the regular body. 

This only replaces text, no logic changes. 
   
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested in the rails console with a factory for distribution and the following 
`User.invite!(email: 'chase@example.com', name: 'chase')`

Verified using letter_opener and inspecting the source.
