### PR TITLE
added xs adult brief size to hash

### DIFF
--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -3,6 +3,7 @@ POSSIBLE_ITEMS = {
     "adult_ml" => "Adult Briefs (Medium/Large)",
     "adult_sm" => "Adult Briefs (Small/Medium)",
     "adult_xxl" => "Adult Briefs (XXL)",
+    "adult_xs" => "Adult Briefs (XS/Small)",
     "cloth" => "Cloth Diapers (Plastic Cover Pants)",
     "disposable_inserts" => "Disposable Inserts",
     "k_newborn" => "Kids (Newborn)",


### PR DESCRIPTION
Resolves #85 

### Description
Referencing rubyforgood/diaper#630 where we added a new cannonical item for X-Small/Small Adult Briefs. We have therefore updated the hash of POSSIBLE_ITEMS to include this brief size.