### PR TITLE
Spelling corrections partner invitation email

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -343,7 +343,7 @@
                   <td>
                     <p>Hi there!</p>
 
-                    <p>You've been invited to become a partner organization to a diaper bank or menstrual supply organization!</p>
+                    <p>You've been invited to become a partner organization with a diaper bank or menstrual supply organization!</p>
                     <p>Please click the link below to accept your invitation and create an account and you'll be able to begin requesting distributions.</p>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                       <tbody>
@@ -363,7 +363,7 @@
                     <% if @resource.invitation_due_at %>
                       <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
                     <% end %>
-                    <p>Feel free to ignore this email if you are no interested or if you feel it was sent by mistake.</p>
+                    <p>Feel free to ignore this email if you are not interested or if you feel it was sent by mistake.</p>
                   </td>
                 </tr>
               </table>


### PR DESCRIPTION
Resolves #80 

### Description
There were two actions in this issue: I have completed one of them; the two spelling mistakes in the email body text. 

I need help on the other, which was to remove or change the placeholder (preheader) text showing on the email preview subject line. Right now, I can't find this text in the codebase. Also, I don't know how to replicate this problem (sending myself an email) to see if I've fixed it. I would really appreciate your advice (more details below if required). Thank you! ❤️ 

### More detail on my problem
I can see in `/app/views/mailer/invitation_instructions.html.erb`there is a class called "preheader", which has been assigned the text "You've been invited to become a partner organization." (line 335). I could hypothesise that this is the text which _should_ be showing in the preview subject line of the partner invitation email, but I'm not sure how to check this without creating a mock email.

I tried logging into Diaper base to see if there was a way I could send myself a mock email. I managed to input my email address to send myself an invite, but it didn't come through. 

I've tried searching the codebase for other text that might help me point to the preview line, such as "accounts@diaper.app" email address and "diaper bank partner invitation" which is the email subject in the screenshot,  but I haven't found the preheader text that I can see in the screenshot in either of those places.

If you have any ideas on what else I could try to solve this problem, I would really appreciate this. Thank you 😃 

