### PR TITLE
fix line item removal bug

### DIFF
--- a/app/assets/javascripts/partner_requests.js
+++ b/app/assets/javascripts/partner_requests.js
@@ -2,7 +2,8 @@ $(document).on('turbolinks:load', function() {
   $('form').on('click', '.remove_record', function(event) {
     $(this).prev('input[type=hidden]').val('1');
     $(this).closest('tr').hide();
-    return event.preventDefault();
+    event.preventDefault();
+    return false
   });
 
   $('form').on('click', '.add_fields', function(event) {
@@ -10,6 +11,7 @@ $(document).on('turbolinks:load', function() {
     time = new Date().getTime();
     regexp = new RegExp($(this).data('id'), 'g');
     $('.fields').append($(this).data('fields').replace(regexp, time));
-    return event.preventDefault();
+    event.preventDefault();
+    return false
   });
 });

--- a/app/views/partner_requests/_item.html.erb
+++ b/app/views/partner_requests/_item.html.erb
@@ -3,6 +3,6 @@
   <td><%= form.number_field :quantity, label: false, step: 1, min: 1, class: 'form-control' %></td>
   <td>
     <%= form.hidden_field :_destroy, as: :hidden %>
-    <%= link_to 'Remove', '#', class: 'remove_record', class: 'btn btn-warning' %>
+    <%= link_to 'Remove', '#', class: 'remove_record btn btn-warning' %>
   </td>
 </tr>


### PR DESCRIPTION
Resolves #86 

### Description
It seems that in some new theming (https://github.com/rubyforgood/partner/pull/68) that we inadvertently added a second `class` argument to the `link_to` in `app/views/partner_requests/_item.html.erb`. This caused the first `class` argument to be ignored which meant that the required `remove_record` class was missing from the button causing the JS in `partner_requests.js` to miss the click event.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested in browser locally. 

### Screenshots
See attached gif. 

![partnerbase_2019-03-05 2019-03-05 21_53_31](https://user-images.githubusercontent.com/7292/53852768-27ad7e00-3f91-11e9-8308-99c20399d20f.gif)
