### PR TITLE
Add NDBN agency type classification drop down form

### DIFF
--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -24,8 +24,7 @@
             <div class="form-group row">
               <label class="control-label col-md-3">Agency Type</label>
               <div class="col-md-8">
-                <%= form.text_field :agency_type, class: "form-control" %>
-
+                  <%= form.select :agency_type, AGENCY_TYPES.values, {}, class: "form-control" %>
               </div>
             </div>
             <div class="form-group row">

--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -39,3 +39,29 @@ POSSIBLE_ITEMS = {
     "cloth_training_pants" => "Cloth Potty Training Pants/Underwear",
     "wipes" => "Wipes (Baby)"
   }
+
+AGENCY_TYPES = {
+    "CAREER" => "Career technical training",
+    "ABUSE" => "Child abuse resource center",
+    "CHURCH" => "Church outreach ministry",
+    "CDC" => "Community development corporation",
+    "HEALTH" => "Community health program",
+    "OUTREACH" => "Community outreach services",
+    "CRISIS" => "Crisis/Disaster services",
+    "DISAB" => "Developmental disabilities program",
+    "DOMV" => "Domestic violence shelter",
+    "CHILD" => "Early childhood services",
+    "EDU" => "Education program",
+    "FAMILY" => "Family resource center",
+    "FOOD" => "Food bank/pantry",
+    "GOVT" => "Government Agency/Affiliate",
+    "HEADSTART" => "Head Start/Early Head Start",
+    "HOMEVISIT" => "Home visits",
+    "HOMELESS" => "Homeless resource center",
+    "INFPAN" => "Infant/Child Pantry/Closet",
+    "PREG" => "Pregnancy resource center",
+    "REF" => "Refugee resource center",
+    "TREAT" => "Treatment clinic",
+    "WIC" => "Women, Infants and Children",
+    "OTHER" => "Other"
+}

--- a/spec/features/partner_edit_feature_spec.rb
+++ b/spec/features/partner_edit_feature_spec.rb
@@ -10,7 +10,7 @@ describe "Partner edit", type: :feature do
 
   it "partner can fill out partner details" do
     fill_in "partner_name", with: Faker::Company.name
-    fill_in "partner_agency_type", with: Faker::Company.suffix
+    select "Career technical training", from: "partner_agency_type"
     fill_in "partner_agency_mission", with: Faker::Lorem.paragraph
     fill_in "partner_address1", with: Faker::Address.street_address
     fill_in "partner_address2", with: Faker::Address.secondary_address


### PR DESCRIPTION
Resolves #75 

### Description
We have created a dropdown box allowing agency users to choose which of the National Diaper Bank Network's classifications their agency falls into.

We did this by adding the NDBN's Agency Type classifications to the list of constants in the initialisers directory. 
We then added a helper method to the form to create a dropdown. 

_This issue will be fully resolved when we have learnt whether the "other" classification requires a description from the agency user, as suggested in the excel spreadsheet supplied._

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

We tested this by submitting the form and checking in the rails console that the database had attributed this new item of information to the partner.

It would also be good to know (for my learning in particular) if any tests are required for this change? I did check the spec directory, but couldn't find a test for this form, but I could easily have missed this.

Thank you @chaserx for pairing with me on this issue ❤️ 
