### PR TITLE
Add other agency type input into form and attribute in database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ group :test do
   gem "chromedriver-helper"
   gem "email_spec"
   gem "selenium-webdriver"
-  gem "shoulda-matchers"
   gem "webmock"
+  gem "shoulda-matchers", "~> 4.0"
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :test do
   gem "chromedriver-helper"
   gem "email_spec"
   gem "selenium-webdriver"
-  gem "shoulda-matchers", "~> 4.0"
+  gem "shoulda-matchers"
   gem "webmock"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ group :test do
   gem "chromedriver-helper"
   gem "email_spec"
   gem "selenium-webdriver"
-  gem "webmock"
   gem "shoulda-matchers", "~> 4.0"
+  gem "webmock"
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -171,7 +171,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.4.0)
     htmlentities (4.3.4)
-    i18n (1.5.3)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
     jaro_winkler (1.5.2)
@@ -418,7 +418,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
-  shoulda-matchers (~> 4.0)
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,8 +327,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.1.0)
+      activesupport (>= 4.2.0)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -418,7 +418,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
-  shoulda-matchers
+  shoulda-matchers (~> 4.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/assets/javascripts/partners.js
+++ b/app/assets/javascripts/partners.js
@@ -1,7 +1,5 @@
 $(document).on('turbolinks:load', function() {
     $('form').on('change', '#partner_agency_type', function(event) {
-        console.log("I changed successfully");
-        console.log($(this).val() == "Other");
         if($(this).val() === "Other") {
             $('#other_agency_input').show();
         } else {

--- a/app/assets/javascripts/partners.js
+++ b/app/assets/javascripts/partners.js
@@ -1,0 +1,12 @@
+$(document).on('turbolinks:load', function() {
+    $('form').on('change', '#partner_agency_type', function(event) {
+        console.log("I changed successfully");
+        console.log($(this).val() == "Other");
+        if($(this).val() === "Other") {
+            $('#other_agency_input').show();
+        } else {
+            $('#other_agency_input').hide();
+        }
+        return false
+    });
+});

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -65,6 +65,7 @@ class PartnersController < ApplicationController
     params.require(:partner).permit(
       :name,
       :agency_type,
+      :other_agency_type,
       :partner_status,
       :proof_of_partner_status,
       :agency_mission,

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -127,6 +127,7 @@ class Partner < ApplicationRecord
       name: name,
       distributor_type: distributor_type,
       agency_type: agency_type,
+      other_agency_type: other_agency_type,
       proof_of_agency_status: expose_attachment_path(proof_of_partner_status),
       agency_mission: agency_mission,
       address: {

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -27,6 +27,12 @@
                   <%= form.select :agency_type, AGENCY_TYPES.values, {}, class: "form-control" %>
               </div>
             </div>
+            <div class="form-group row" id="other_agency_input" style="display:none">
+              <label class="control-label col-md-3">Other Agency Type</label>
+              <div class="col-md-8">
+                <%= form.text_field :other_agency_type, class: "form-control" %>
+              </div>
+            </div>
             <div class="form-group row">
               <label class="control-label col-md-3">Proof of Partner Status</label>
               <% if partner.proof_of_partner_status.attached? %>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -32,6 +32,11 @@
                   <dt>Agency Type</dt>
                   <dd><%= @partner.agency_type %></dd>
 
+                  <% if @partner.agency_type == "Other" %>
+                    <dt>Other Agency Type</dt>
+                    <dd><%= @partner.other_agency_type %></dd>
+                  <% end %>
+
                   <dt>Status</dt>
                   <dd><%= @partner.partner_status %></dd>
 

--- a/db/migrate/20190315202706_add_other_agency_type_to_partners.rb
+++ b/db/migrate/20190315202706_add_other_agency_type_to_partners.rb
@@ -1,0 +1,5 @@
+class AddOtherAgencyTypeToPartners < ActiveRecord::Migration[5.2]
+  def change
+    add_column :partners, :other_agency_type, :string
+  end
+end

--- a/spec/features/partner_edit_feature_spec.rb
+++ b/spec/features/partner_edit_feature_spec.rb
@@ -8,7 +8,15 @@ describe "Partner edit", type: :feature do
     visit "/partners/#{partner.id}/edit"
   end
 
-  it "partner can fill out partner details" do
+  scenario "partner can select and provide an Other agency type", js: true do
+    select "Other", from: "partner_agency_type"
+    fill_in "partner_other_agency_type", with: Faker::Name.name
+    click_button "Update Information"
+
+    expect(page).to have_content "Details were successfully updated."
+  end
+
+  scenario "partner can fill out partner details" do
     fill_in "partner_name", with: Faker::Company.name
     select "Career technical training", from: "partner_agency_type"
     fill_in "partner_agency_mission", with: Faker::Lorem.paragraph
@@ -87,7 +95,7 @@ describe "Partner edit", type: :feature do
     expect(page).to have_content "Details were successfully updated."
   end
 
-  it "partner can attach documents" do
+  scenario "partner can attach documents" do
     attach_file("partner_proof_of_partner_status", Rails.root + "spec/fixtures/test.pdf")
     attach_file("partner_proof_of_form_990", Rails.root + "spec/fixtures/test.pdf")
     attach_file("partner_documents", Rails.root + "spec/fixtures/test.pdf")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "factory_bot"
 require "devise"
+require "capybara/rails"
+require "capybara/rspec"
+require "capybara-screenshot/rspec"
 require_relative "support/controller_macros"
 # Add additional requires below this line. Rails is not loaded until this point!
 Shoulda::Matchers.configure do |config|
@@ -34,6 +37,31 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+
+# If an element is hidden, Capybara should ignore it
+Capybara.ignore_hidden_elements = true
+
+# https://docs.travis-ci.com/user/chrome
+Capybara.register_driver :chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu window-size=1680,1050])
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+# Enable JS for Capybara tests
+Capybara.javascript_driver = :chrome
+
+Capybara::Screenshot.autosave_on_failure = true
+# The driver name should match the Capybara driver config name.
+Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+# Set the asset host so that the screenshots look nice
+Capybara.asset_host = "http://localhost:3000"
+
+# Only keep the most recent run
+Capybara::Screenshot.prune_strategy = :keep_last_run
 
 # NOTE(chaserx): this is required to include fixture_file_upload in factories
 # see also: https://blog.eq8.eu/til/factory-bot-trait-for-active-storange-has_attached.html


### PR DESCRIPTION
Resolves #92 

### Description
@chaserx and I added a text input field into the partner agency form so that users can describe their agency type if they choose to identify as "Other" from the NDBA agency type list. This is then committed to the database.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
We tested this in the rails console, but need to add a test in the spec directory and will do this shortly.
