### PR TITLE
Corresponding changes for use with Diaper PR#820 - Partner Re-certification

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -20,7 +20,15 @@ class Api::V1::PartnersController < ApiController
     return head :forbidden unless api_key_valid?
 
     partner = Partner.find_by(diaper_partner_id: partner_params[:diaper_partner_id])
-    partner.update(partner_status: "Verified")
+    if partner_params[:status] == "pending"
+      partner.update(partner_status: "pending")
+    elsif partner_params[:status] == "recertification_required"
+      partner.update(partner_status: "Recertification Required")
+    elsif partner_params[:status] == "approved"
+      partner.update(partner_status: "Verified")
+    else
+      partner.update(partner_status: "pending")
+    end
     render json: { message: "Partner status changed to verified." }, status: :ok
   rescue ActiveRecord::RecordInvalid => e
     render e.message
@@ -46,7 +54,8 @@ class Api::V1::PartnersController < ApiController
     params.require(:partner).permit(
       :diaper_bank_id,
       :diaper_partner_id,
-      :email
+      :email,
+      :status
     )
   end
 end

--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -7,7 +7,7 @@ class PartnerRequestsController < ApplicationController
   end
 
   def new
-    if current_partner.approved?
+    if current_partner.partner_status == "Approved"
       @partner_request = PartnerRequest.new
       @valid_items = DiaperBankClient.get_available_items(current_partner.diaper_bank_id)
       @valid_items = @valid_items.map { |item| [item["name"], item["id"]] }

--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -7,8 +7,14 @@ class PartnerRequestsController < ApplicationController
   end
 
   def new
-    @partner_request = PartnerRequest.new
-    @partner_request.item_requests.build # required to render the empty items form
+    if current_partner.approved?
+      @partner_request = PartnerRequest.new
+      @valid_items = DiaperBankClient.get_available_items(current_partner.diaper_bank_id)
+      @valid_items = @valid_items.map { |item| [item["name"], item["id"]] }
+      @partner_request.item_requests.build # required to render the empty items form
+    else
+      redirect_to partner_requests_path, notice: "Please review your application details and submit for approval in order to make a new request."
+    end
   end
 
   def create

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,8 @@ module ApplicationHelper
       content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-primary", "float-right"]
     elsif @partner.partner_status == "Recertification Required"
       content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-danger", "float-right"]
+    else
+      content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-info", "float-right"]
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,12 @@ module ApplicationHelper
   def valid_items_for_select(items)
     items.map { |item| [item["name"], item["id"]] }.sort
   end
+
+  def partner_status_badge(partner)
+    if @partner.partner_status == "Verified"
+      content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-primary", "float-right"]
+    elsif @partner.partner_status == "Recertification Required"
+      content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-danger", "float-right"]
+    end
+  end
 end

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,6 +1,8 @@
 <div class="app-title">
   <div>
-    <h1><i class="fa fa-dashboard"></i> Organization Details &nbsp<span class="badge badge-pill badge-primary float-right"><%= @partner.partner_status %></span></h1>
+
+    <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;Please review your application details and submit for approval.</div>
+    <h1><i class="fa fa-dashboard"></i> Organization Details &nbsp <%= partner_status_badge(@partner) %></h1>
   </div>
   <ul class="app-breadcrumb breadcrumb">
     <li class="breadcrumb-item"><i class="fa fa-home fa-lg"></i></li>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,7 +1,8 @@
 <div class="app-title">
   <div>
-
-    <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;Please review your application details and submit for approval.</div>
+    <% if @partner.partner_status == "Recertification Required" %>
+      <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;Please review your application details and submit for approval.</div>
+    <% end %>
     <h1><i class="fa fa-dashboard"></i> Organization Details &nbsp <%= partner_status_badge(@partner) %></h1>
   </div>
   <ul class="app-breadcrumb breadcrumb">

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -331,19 +331,24 @@
       </div>
     </div>
 </div>
-<div class="col-md-12">
+<div class="col-md-10 offset-md-1">
   <div class="tile">
     <div class="tile-body">
       <div class="row">
         <div class="form-group col-md-6">
-
-        <% if @partner.verified? %>
-          <%= link_to 'Request Diapers', partner_requests_path, class: 'btn btn-success' %>
-        <% end %>
-        <% unless @partner.verified? %>
-          <%= link_to 'Submit for Approval', partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending?}" %>
-        <% end %>
-        <%= link_to 'Update Information', edit_partner_path(@partner), class: "btn btn-primary float-right" %>
+          <div class="actions">
+            <% if @partner.verified? %>
+              <%= link_to "Request Diapers", partner_requests_path, class: 'btn btn-success' %>
+            <% end %>
+            <% unless @partner.verified? %>
+              <%= link_to partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending? || @partner.partner_status == "Recertification Required"}" do %>
+                <i class="fa fa-paper-plane"></i> Submit for Approval
+              <% end %>
+            <% end %>
+            <%= link_to edit_partner_path(@partner), class: 'btn btn-primary' do %>
+              <i class="fa fa-pencil"></i> Update Information
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_003648) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.string "other_agency_type"
     t.index ["diaper_bank_id"], name: "index_partners_on_diaper_bank_id"
     t.index ["email"], name: "index_partners_on_email", unique: true
     t.index ["invitation_token"], name: "index_partners_on_invitation_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,19 +1,11 @@
 require 'faker'
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 puts "Creating partners..."
 puts "Adding an 'approved' partner."
 Partner.create(
     executive_director_name: "Leslie Knope",
     program_contact_name: "Leslie Knope",
-    name: "Pawnee Indiana Diaper Bank Partner",
+    name: "Pawnee Parent Service",
     address1: "123 Main St",
     address2: "",
     city: "Pawnee",
@@ -46,4 +38,68 @@ Partner.create(
     email: "unverified@example.com",
     password: "password"
 )
+
+puts "Adding a 'invited' partner."
+Partner.create(
+    name: "Pawnee Homeless Shelter",
+    email: "anyone@pawneehomelss.com",
+    partner_status: "invited",
+    diaper_bank_id: 1,
+    diaper_partner_id: 2,
+    executive_director_name: Faker::Name.name,
+    program_contact_name: Faker::Name.name,
+    name: "County Diaper Bank",
+    address1: Faker::Address.street_address,
+    address2: "",
+    city: Faker::Address.city,
+    state: Faker::Address.state_abbr,
+    zip_code: Faker::Address.zip,
+    website: Faker::Internet.domain_name,
+    zips_served: Faker::Address.zip,
+    executive_director_email: "anyone@pawneehomelss.com",
+    password: "password"
+)
+
+puts "Adding a 'invited' partner."
+Partner.create(
+    name: "Pawnee Pregnancy Center",
+    email: "contactus@pawneepregnancy.com",
+    partner_status: "invited",
+    diaper_bank_id: 1,
+    diaper_partner_id: 3,
+    executive_director_name: Faker::Name.name,
+    program_contact_name: Faker::Name.name,
+    name: "County Diaper Bank",
+    address1: Faker::Address.street_address,
+    address2: "",
+    city: Faker::Address.city,
+    state: Faker::Address.state_abbr,
+    zip_code: Faker::Address.zip,
+    website: Faker::Internet.domain_name,
+    zips_served: Faker::Address.zip,
+    executive_director_email: "contactus@pawneepregnancy.com",
+    password: "password"
+)
+
+puts "Adding a 'recertification_required' partner."
+Partner.create(
+    name: "Pawnee Senior Citizens Center",
+    email: "help@pscc.org",
+    partner_status: "recertification_required",
+    diaper_bank_id: 1,
+    diaper_partner_id: 5,
+    executive_director_name: Faker::Name.name,
+    program_contact_name: Faker::Name.name,
+    name: "County Diaper Bank",
+    address1: Faker::Address.street_address,
+    address2: "",
+    city: Faker::Address.city,
+    state: Faker::Address.state_abbr,
+    zip_code: Faker::Address.zip,
+    website: Faker::Internet.domain_name,
+    zips_served: Faker::Address.zip,
+    executive_director_email: "help@pscc.org",
+    password: "password"
+)
+
 puts "Done creating partners."

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -2,12 +2,23 @@ require "rails_helper"
 
 describe PartnerRequestsController, type: :controller do
   context "when authenticated" do
-    login_partner
+    context "when approved" do
+      login_partner(partner_status: "Approved")
+      describe "GET #new" do
+        it "returns http success" do
+          get :new
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
 
-    describe "GET #new" do
-      it "returns http success" do
-        get :new
-        expect(response).to have_http_status(200)
+    context "when pending" do
+      login_partner
+      describe "GET #new" do
+        it "returns http success" do
+          get :new
+          expect(response).to have_http_status(302)
+        end
       end
     end
   end

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -11,17 +11,18 @@ describe PartnerRequestsController, type: :controller do
           # We get at @partner from the login_partner method above
           #
           id = @partner.diaper_bank_id
-          stub_request(:get, "https://diaper.test/partner_requests/#{id}").
-           with(
-             headers: {
-            'Accept'=>'*/*',
-            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type'=>'application/json',
-            'Host'=>'diaper.test',
-            'User-Agent'=>'Ruby',
-            'X-Api-Key'=>'diaperkey'
-             }).
-           to_return(status: 200, body: "{}", headers: {})
+          stub_request(:get, "https://diaper.test/partner_requests/#{id}")
+            .with(
+              headers: {
+                "Accept" => "*/*",
+             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+             "Content-Type" => "application/json",
+             "Host" => "diaper.test",
+             "User-Agent" => "Ruby",
+             "X-Api-Key" => "diaperkey"
+              }
+            )
+            .to_return(status: 200, body: "{}", headers: {})
 
           get :new
           expect(response).to have_http_status(200)

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -6,6 +6,23 @@ describe PartnerRequestsController, type: :controller do
       login_partner(partner_status: "Approved")
       describe "GET #new" do
         it "returns http success" do
+          # NOTE(chaserx): curious that this stub is required here and not
+          #    elsewhere.
+          # We get at @partner from the login_partner method above
+          #
+          id = @partner.diaper_bank_id
+          stub_request(:get, "https://diaper.test/partner_requests/#{id}").
+           with(
+             headers: {
+            'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type'=>'application/json',
+            'Host'=>'diaper.test',
+            'User-Agent'=>'Ruby',
+            'X-Api-Key'=>'diaperkey'
+             }).
+           to_return(status: 200, body: "{}", headers: {})
+
           get :new
           expect(response).to have_http_status(200)
         end

--- a/spec/factories/partner_factory.rb
+++ b/spec/factories/partner_factory.rb
@@ -119,6 +119,18 @@ FactoryBot.define do
       partner_status { "approved" }
     end
 
+    trait(:verified) do
+      partner_status { "Verified" }
+    end
+
+    trait(:recertification_required) do
+      partner_status { "Recertification Required" }
+    end
+
+    trait(:submitted) do
+      partner_status { "submitted" }
+    end
+
     trait(:with_990_attached) do
       proof_of_form_990 { fixture_file_upload(Rails.root.join("spec", "support", "dummy_pdfs", "f990.pdf"), "application/pdf") }
     end

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -49,10 +49,10 @@ describe "Partners Api Requests" do
   end
 
   def valid_partner_creation_request(
-        email: "test@example.com",
-        diaper_bank_id: "diaper-bank-id",
-        diaper_partner_id: "diaper-partner-id"
-      )
+    email: "test@example.com",
+    diaper_bank_id: "diaper-bank-id",
+    diaper_partner_id: "diaper-partner-id"
+  )
     post api_v1_partners_path(
       partner: {
         email: email,

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,5 +1,5 @@
 module ControllerMacros
-  def login_partner(options={})
+  def login_partner(options = {})
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:partner]
       @partner = create(:partner, options)

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,8 +1,8 @@
 module ControllerMacros
-  def login_partner
+  def login_partner(options={})
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:partner]
-      @partner = create(:partner)
+      @partner = create(:partner, options)
       sign_in @partner
     end
   end


### PR DESCRIPTION
### Corresponding Diaperbase PR and Issue

Related to https://github.com/rubyforgood/diaper/pull/820
and https://github.com/rubyforgood/diaper/issue/773

### Description
Here, we are making changes to allow for the recertification partner flow. 

This includes updating partner status from that status saved on `diaper`. This also includes showing the partner status and restricting new diaper requests if the partner status is not approved. 

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- This has been tested by the automated test suite
- This has been tested manually with a local running copy of diaper

### Screenshots

<img width="807" alt="Screen Shot 2019-05-18 at 10 01 04 AM" src="https://user-images.githubusercontent.com/7292/57972989-ced66a80-796f-11e9-8f5b-6d93e2d1e18f.png">

<img width="423" alt="Screen Shot 2019-05-18 at 10 02 28 AM" src="https://user-images.githubusercontent.com/7292/57972994-d5fd7880-796f-11e9-9ff5-80c87dc8763b.png">
