### PR TITLE
Clean up the wording, input and so on of the family and children fields.

### DIFF
--- a/app/assets/stylesheets/bootstrap.min.css
+++ b/app/assets/stylesheets/bootstrap.min.css
@@ -258,7 +258,6 @@ button,
 select,
 optgroup,
 textarea {
-    margin: 0;
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -70,7 +70,6 @@ class ChildrenController < ApplicationController
     params.require(:child).permit(
       :active,
       :agency_child_id,
-      :child_lives_with,
       :comments,
       :date_of_birth,
       :first_name,
@@ -78,7 +77,9 @@ class ChildrenController < ApplicationController
       :health_insurance,
       :item_needed_diaperid,
       :last_name,
-      :race
+      :race,
+      :archived,
+      child_lives_with: []
     )
   end
 end

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -72,8 +72,8 @@ class FamiliesController < ApplicationController
       :home_adult_count,
       :home_child_count,
       :home_young_child_count,
-      :sources_of_income,
-      :military
+      :military,
+      sources_of_income: []
     )
   end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -20,6 +20,8 @@
 #
 
 class Child < ApplicationRecord
+  CAN_LIVE_WITH = %w[Mother Father Grandparent Foster\ Parent Other\ Parent/Relative].freeze
+  serialize :child_lives_with, Array
   belongs_to :family
   has_many :family_request_child, dependent: :destroy
   has_many :family_requests, through: :family_request_child

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -27,6 +27,9 @@
 class Family < ApplicationRecord
   belongs_to :partner
   has_many :children, dependent: :destroy
+  serialize :sources_of_income, Array
+
+  INCOME_TYPES = %w[SSI SNAP/FOOD\ Stamps TANF WIC Housing/subsidized Housing/unsubsidized N/A].freeze
 
   def guardian_display_name
     "#{guardian_first_name} #{guardian_last_name}"

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -105,7 +105,7 @@
 class Partner < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  ACTIVE_FAMILY_REQUESTS = [3, 27].freeze
+  ACTIVE_FAMILY_REQUESTS = [1, 3, 27].freeze
 
   devise :invitable, :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -49,14 +49,17 @@
           <div class="form-horizontal">
             <div class="form-group row">
               <%= form.label :child_lives_with, class: "control-label col-md-3"%>
-              <%= form.text_field :child_lives_with, class: "col-md-8 form-control" %>
+              <% Child::CAN_LIVE_WITH.each do |a_value| %>
+                <%= form.check_box(:child_lives_with, { :multiple => true }, a_value, nil) %>
+                <%= form.label "#{a_value}" %>
+            <% end %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
               <%= form.label :race, class: "control-label col-md-3" %>
-              <%= form.select :race, ["African American", "Caucasian", "Hispanic", "Asian", "American Indian", "Pacific Islander", "Multi-racial", "Other"], class: "col-md-8 form-control" %>
+              <%= form.select :race, ["African American", "Caucasian", "Hispanic", "Asian", "American Indian", "Pacific Islander", "Multi-racial", "Other"], class: "col-md-8 form-control", :include_blank => true %>
             </div>
           </div>
 
@@ -70,7 +73,12 @@
           <div class="form-horizontal">
             <div class="form-group row">
               <%= form.label :health_insurance, class: "control-label col-md-3"%>
-              <%= form.text_field :health_insurance, class: "col-md-8 form-control" %>
+              <%= form.radio_button :health_insurance, 'Private Insurance' %>
+              <%= label :health_insurance, 'Private Insurance' %>
+              <%= form.radio_button :health_insurance, 'Medicaid' %>
+              <%= label :health_insurance, 'Medicaid' %>
+              <%= form.radio_button :health_insurance, 'Uninsured' %>
+              <%= label :health_insurance, 'Uninsured' %>
             </div>
           </div>
 
@@ -102,6 +110,13 @@
             <div class="form-group row">
               <%= form.label :active, class: "control-label col-md-3"%>
               <%= form.check_box :active, class: "col-md-8 form-control" %>
+            </div>
+          </div>
+
+          <div class="form-horizontal">
+            <div class="form-group row">
+              <%= form.label "Archived?", class: "control-label col-md-3"%>
+              <%= form.check_box :archived, class: "col-md-8 form-control" %>
             </div>
           </div>
 

--- a/app/views/children/show.html.erb
+++ b/app/views/children/show.html.erb
@@ -36,7 +36,7 @@
               <dd><%= child.gender %></dd>
 
               <dt>Child lives with:</dt>
-              <dd><%= child.child_lives_with %></dd>
+              <dd><%= child.child_lives_with.join(', ') %></dd>
 
               <dt>Race:</dt>
               <dd><%= child.race %></dd>

--- a/app/views/families/_form.html.erb
+++ b/app/views/families/_form.html.erb
@@ -39,7 +39,7 @@
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :guardian_country, class: "control-label col-md-3" %>
+              <%= form.label :guardian_country, "Guardian County", class: "control-label col-md-3" %>
               <%= form.text_field :guardian_country, class: "col-md-8 form-control" %>
             </div>
           </div>
@@ -60,43 +60,54 @@
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :home_adult_count, class: "control-label col-md-3" %>
+              <%= form.label :home_adult_count, "Number of Adults Living In The Home", class: "control-label col-md-3" %>
               <%= form.number_field :home_adult_count, class: "col-md-8 form-control" %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :home_child_count, class: "control-label col-md-3" %>
+              <%= form.label :home_child_count, 'How Many Children (5-17) Live In the Home?', class: "control-label col-md-3" %>
               <%= form.number_field :home_child_count, class: "col-md-8 form-control" %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :home_young_child_count, class: "control-label col-md-3" %>
+              <%= form.label :home_young_child_count, 'How Many Children (under 5) Live in the Home?', class: "control-label col-md-3" %>
               <%= form.number_field :home_young_child_count, class: "col-md-8 form-control" %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :sources_of_income, class: "control-label col-md-3" %>
-              <%= form.text_field :sources_of_income, class: "col-md-8 form-control" %>
+              <%= form.label :sources_of_income, class: "control-label col-md-3"%>
+              <% Family::INCOME_TYPES.each do |a_value| %>
+                <%= form.check_box(:sources_of_income, { :multiple => true }, a_value, nil) %>
+                <%= form.label "#{a_value}" %>
+              <% end %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :guardian_employed, class: "control-label col-md-3" %>
-              <%= form.check_box :guardian_employed, class: "col-md-8 form-control" %>
+              <%= form.label :guardian_employed, "Is The Parent/Guardian Employed?", class: "control-label col-md-3" %>
+              <%= form.radio_button :guardian_employed, 'Yes' %>
+              <%= label :guardian_employed, 'Yes' %>
+              <%= form.radio_button :guardian_employed, 'No' %>
+              <%= label :guardian_employed, 'No' %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :guardian_employment_type, class: "control-label col-md-3" %>
-              <%= form.text_field :guardian_employment_type, class: "col-md-8 form-control" %>
+              <%= form.label :guardian_employment_type, "Full-Time or Part-Time", class: "control-label col-md-3" %>
+              <%= form.radio_button :guardian_employment_type, 'Full-Time' %>
+              <%= label :guardian_employment_type, 'Full-Time' %>
+              <%= form.radio_button :guardian_employment_type, 'Part-Time' %>
+              <%= label :guardian_employment_type, 'Part-Time' %>
+              <%= form.radio_button :guardian_employment_type, 'N/A' %>
+              <%= label :guardian_employment_type, 'N/A' %>
             </div>
           </div>
 
@@ -109,19 +120,22 @@
 
           <div class="form-horizontal">
             <div class="form-group row">
-              <%= form.label :guardian_health_insurance, class: "control-label col-md-3" %>
-              <%= form.text_field :guardian_health_insurance, class: "col-md-8 form-control" %>
+              <%= form.label :guardian_health_insurance, class: "control-label col-md-3"%>
+              <%= form.radio_button :guardian_health_insurance, 'Private Insurance' %>
+              <%= label :guardian_health_insurance, 'Private Insurance' %>
+              <%= form.radio_button :guardian_health_insurance, 'Medicaid' %>
+              <%= label :guardian_health_insurance, 'Medicaid' %>
+              <%= form.radio_button :guardian_health_insurance, 'Uninsured' %>
+              <%= label :guardian_health_insurance, 'Uninsured' %>
             </div>
           </div>
 
           <div class="form-horizontal">
             <div class="form-group row">
               <%= form.label :military, "Military Family", class: "control-label col-md-3" %>
-              <div class="form-control col-md-8">
                 <%= form.radio_button :military, true %> Yes
                 &nbsp;
                 <%= form.radio_button :military, false %> No
-              </div>
             </div>
           </div>
 

--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -32,7 +32,7 @@
               <dt>Guardian zip code:</dt>
               <dd><%= family.guardian_zip_code %></dd>
 
-              <dt>Guardian country:</dt>
+              <dt>Guardian county:</dt>
               <dd><%= family.guardian_country %></dd>
 
               <dt>Guardian phone:</dt>
@@ -51,7 +51,7 @@
               <dd><%= family.home_young_child_count %></dd>
 
               <dt>Sources of income:</dt>
-              <dd><%= family.sources_of_income %></dd>
+              <dd><%= family.sources_of_income.join(', ') %></dd>
 
               <dt>Guardian employed:</dt>
               <dd><%= family.guardian_employed %></dd>

--- a/db/migrate/20190721044143_add_archived_to_child.rb
+++ b/db/migrate/20190721044143_add_archived_to_child.rb
@@ -1,0 +1,5 @@
+class AddArchivedToChild < ActiveRecord::Migration[5.2]
+  def change
+    add_column :children, :archived, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_29_182738) do
+ActiveRecord::Schema.define(version: 2019_07_21_044143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2019_06_29_182738) do
     t.bigint "family_id"
     t.integer "item_needed_diaperid"
     t.boolean "active", default: true
+    t.boolean "archived"
     t.index ["family_id"], name: "index_children_on_family_id"
   end
 

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     date_of_birth { Faker::Date.backward(14).iso8601 }
     active { true }
     gender { Faker::Gender.type }
-    child_lives_with { "Parent" }
+    child_lives_with { ["Mother"] }
     race { "Unknown" }
     item_needed_diaperid { 1 }
     agency_child_id { "Agency" }

--- a/spec/factories/families.rb
+++ b/spec/factories/families.rb
@@ -35,11 +35,11 @@ FactoryBot.define do
     home_adult_count { 1 }
     home_child_count { 1 }
     home_young_child_count { 1 }
-    sources_of_income { "" }
+    sources_of_income { ["WIC"] }
     guardian_employed { false }
     guardian_employment_type { "" }
     guardian_monthly_pay { "9.99" }
-    guardian_health_insurance { "" }
+    guardian_health_insurance { "Uninsured" }
     military { false }
     comments { "MyText" }
     partner


### PR DESCRIPTION
This is almost entirely a formatting/copy fix. This PR changes the language used on the various fields on the children/families pages to match what the diaper banks wanted. 

There is a single migration to add an additional field `archived` to the children to denote when they age out of being able to receive diapers but they want to keep their info in the system for historical/reporting data. I'll likely create another Issue (and PR?) to ensure that archived kids don't show up in the family request list.