### PR TITLE
Add status changing tests to partner request spec

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::PartnersController < ApiController
   def update
     return head :forbidden unless api_key_valid?
 
-    partner = Partner.find_by(diaper_partner_id: partner_params[:diaper_partner_id])
+    partner = Partner.find_by!(diaper_partner_id: partner_params[:diaper_partner_id])
     if partner_params[:status] == "pending"
       partner.update(partner_status: "pending")
     elsif partner_params[:status] == "recertification_required"
@@ -29,8 +29,9 @@ class Api::V1::PartnersController < ApiController
     else
       partner.update(partner_status: "pending")
     end
-    render json: { message: "Partner status changed to verified." }, status: :ok
-  rescue ActiveRecord::RecordInvalid => e
+
+    render json: { message: "Partner status: #{partner.partner_status}." }, status: :ok
+  rescue ActiveRecord::RecordNotFound => e
     render e.message
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,8 @@ Rails.application.routes.draw do
   get "/api", action: :show, controller: "api"
   namespace :api, defaults: { format: "json" } do
     namespace :v1 do
-      resources :partners
+      resources :partners, only: [:create, :show]
+      resource :partners, only: [:update]
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Partners Api Requests" do
+describe "Partners API Requests", type: :request do
   describe "GET /api/v1/partners/1" do
     let(:partner) { create(:partner) }
 
@@ -48,6 +48,85 @@ describe "Partners Api Requests" do
     end
   end
 
+  describe "PUT /api/v1/partners" do
+    let(:headers) { {'X-Api-Key': ENV["DIAPER_KEY"]} }
+
+    context "when we set the partner to pending" do
+      let(:partner) { create(:partner) }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "pending" }} }
+
+      it 'returns OK' do
+        valid_partner_update_request(params, headers)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'sets the status to pending' do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.partner_status).to eq("pending")
+      end
+    end
+
+    context "when we set the partner to recertification_required" do
+      let(:partner) { create(:partner) }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "recertification_required" }} }
+
+      it 'returns OK' do
+        valid_partner_update_request(params, headers)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'sets the status to Recertification Required' do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.partner_status).to eq("Recertification Required")
+      end
+
+      it 'shows recertification required status in the response body' do
+        valid_partner_update_request(params, headers)
+        expect(JSON.parse(response.body)['message']).to eq('Partner status: Recertification Required.')
+      end
+    end
+
+    context "when we set the partner to approved" do
+      let(:partner) { create(:partner) }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "approved" }} }
+
+      it 'returns OK' do
+        valid_partner_update_request(params, headers)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'sets the status to Verified' do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.partner_status).to eq("Verified")
+      end
+
+      it 'shows verified status in the response body' do
+        valid_partner_update_request(params, headers)
+        expect(JSON.parse(response.body)['message']).to eq('Partner status: Verified.')
+      end
+    end
+
+    context "when we try to set the partner to blarg" do
+      let(:partner) { create(:partner) }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" }} }
+
+      it 'returns OK' do
+        valid_partner_update_request(params, headers)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'sets the status to pending' do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.partner_status).to eq("pending")
+      end
+
+      it 'shows pending status in the response body' do
+        valid_partner_update_request(params, headers)
+        expect(JSON.parse(response.body)['message']).to eq('Partner status: pending.')
+      end
+    end
+  end
+
   def valid_partner_creation_request(
     email: "test@example.com",
     diaper_bank_id: "diaper-bank-id",
@@ -60,5 +139,9 @@ describe "Partners Api Requests" do
         diaper_partner_id: diaper_partner_id
       }
     )
+  end
+
+  def valid_partner_update_request(params, headers={})
+    put '/api/v1/partners', params: params, headers: headers, as: :json
   end
 end

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -49,18 +49,18 @@ describe "Partners API Requests", type: :request do
   end
 
   describe "PUT /api/v1/partners" do
-    let(:headers) { {'X-Api-Key': ENV["DIAPER_KEY"]} }
+    let(:headers) { { 'X-Api-Key': ENV["DIAPER_KEY"] } }
 
     context "when we set the partner to pending" do
       let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "pending" }} }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "pending" } } }
 
-      it 'returns OK' do
+      it "returns OK" do
         valid_partner_update_request(params, headers)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'sets the status to pending' do
+      it "sets the status to pending" do
         valid_partner_update_request(params, headers)
         expect(partner.reload.partner_status).to eq("pending")
       end
@@ -68,61 +68,61 @@ describe "Partners API Requests", type: :request do
 
     context "when we set the partner to recertification_required" do
       let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "recertification_required" }} }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "recertification_required" } } }
 
-      it 'returns OK' do
+      it "returns OK" do
         valid_partner_update_request(params, headers)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'sets the status to Recertification Required' do
+      it "sets the status to Recertification Required" do
         valid_partner_update_request(params, headers)
         expect(partner.reload.partner_status).to eq("Recertification Required")
       end
 
-      it 'shows recertification required status in the response body' do
+      it "shows recertification required status in the response body" do
         valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)['message']).to eq('Partner status: Recertification Required.')
+        expect(JSON.parse(response.body)["message"]).to eq("Partner status: Recertification Required.")
       end
     end
 
     context "when we set the partner to approved" do
       let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "approved" }} }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "approved" } } }
 
-      it 'returns OK' do
+      it "returns OK" do
         valid_partner_update_request(params, headers)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'sets the status to Verified' do
+      it "sets the status to Verified" do
         valid_partner_update_request(params, headers)
         expect(partner.reload.partner_status).to eq("Verified")
       end
 
-      it 'shows verified status in the response body' do
+      it "shows verified status in the response body" do
         valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)['message']).to eq('Partner status: Verified.')
+        expect(JSON.parse(response.body)["message"]).to eq("Partner status: Verified.")
       end
     end
 
     context "when we try to set the partner to blarg" do
       let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" }} }
+      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" } } }
 
-      it 'returns OK' do
+      it "returns OK" do
         valid_partner_update_request(params, headers)
         expect(response).to have_http_status(:ok)
       end
 
-      it 'sets the status to pending' do
+      it "sets the status to pending" do
         valid_partner_update_request(params, headers)
         expect(partner.reload.partner_status).to eq("pending")
       end
 
-      it 'shows pending status in the response body' do
+      it "shows pending status in the response body" do
         valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)['message']).to eq('Partner status: pending.')
+        expect(JSON.parse(response.body)["message"]).to eq("Partner status: pending.")
       end
     end
   end
@@ -141,7 +141,7 @@ describe "Partners API Requests", type: :request do
     )
   end
 
-  def valid_partner_update_request(params, headers={})
-    put '/api/v1/partners', params: params, headers: headers, as: :json
+  def valid_partner_update_request(params, headers = {})
+    put "/api/v1/partners", params: params, headers: headers, as: :json
   end
 end


### PR DESCRIPTION
### Description

This increases the test coverage for the Partner API. Specifically, it adds tests for each status change. 

There's also some minor cleanup to the routes to reflect how we're using the routes currently and to the response that we provide on partner update. 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* tests run/pass locally
* CI
* **should verify that the client applications still work**