### PR TITLE
Refactor app to use consistent partner statuses

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -23,10 +23,10 @@ class Api::V1::PartnersController < ApiController
     if partner_params[:status] == "pending"
       partner.update(partner_status: "pending")
     elsif partner_params[:status] == "recertification_required"
-      partner.update(partner_status: "Recertification Required")
+      partner.update(partner_status: "recertification_required")
       RecertificationMailer.with(partner: partner).notice_email.deliver_now
     elsif partner_params[:status] == "approved"
-      partner.update(partner_status: "Verified")
+      partner.update(partner_status: "verified")
     else
       partner.update(partner_status: "pending")
     end

--- a/app/controllers/partner_requests_controller.rb
+++ b/app/controllers/partner_requests_controller.rb
@@ -7,7 +7,7 @@ class PartnerRequestsController < ApplicationController
   end
 
   def new
-    if current_partner.partner_status == "Verified"
+    if current_partner.partner_status == "verified"
       @partner_request = PartnerRequest.new
       @partner_request.item_requests.build # required to render the empty items form
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,9 +12,9 @@ module ApplicationHelper
   end
 
   def partner_status_badge(partner)
-    if @partner.partner_status == "Verified"
+    if @partner.partner_status == "verified"
       content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-primary", "float-right"]
-    elsif @partner.partner_status == "Recertification Required"
+    elsif @partner.partner_status == "recertification_required"
       content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-danger", "float-right"]
     else
       content_tag :span, partner.partner_status, class: ["badge", "badge-pill", "badge-info", "float-right"]

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -234,7 +234,7 @@ class Partner < ApplicationRecord
   end
 
   def approve_me
-    update(partner_status: "Submitted")
+    update(partner_status: "submitted")
     DiaperBankClient.post(diaper_partner_id)
   end
 

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,6 +1,6 @@
 <div class="app-title">
   <div>
-    <% if @partner.partner_status == "Recertification Required" %>
+    <% if @partner.partner_status == "recertification_required" %>
       <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;Please review your application details and submit for approval.</div>
     <% end %>
     <h1><i class="fa fa-dashboard"></i> Organization Details &nbsp <%= partner_status_badge(@partner) %></h1>
@@ -38,7 +38,7 @@
                   <% end %>
 
                   <dt>Status</dt>
-                  <dd><%= @partner.partner_status %></dd>
+                  <dd><%= @partner.partner_status.humanize %></dd>
 
                   <dt>Proof of Partner Status</dt>
                   <% if @partner.proof_of_partner_status.attached? %>
@@ -347,7 +347,7 @@
               <%= link_to "Request Diapers", partner_requests_path, class: 'btn btn-success' %>
             <% end %>
             <% unless @partner.verified? %>
-              <%= link_to partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending? || @partner.partner_status == "Recertification Required"}" do %>
+              <%= link_to partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending? || @partner.partner_status == "recertification_required"}" do %>
                 <i class="fa fa-paper-plane"></i> Submit for Approval
               <% end %>
             <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ Partner.create(
     executive_director_email: "verified@example.com",
     email: "verified@example.com",
     password: "password",
-    partner_status: "Verified"
+    partner_status: "verified"
 )
 
 puts "Adding a generic 'pending' partner."

--- a/spec/controllers/partner_requests_controller_spec.rb
+++ b/spec/controllers/partner_requests_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe PartnerRequestsController, type: :controller do
   context "when authenticated" do
     context "when approved" do
-      login_partner(partner_status: "Verified")
+      login_partner(partner_status: "verified")
       describe "GET #new" do
         it "returns http success" do
           # NOTE(chaserx): curious that this stub is required here and not

--- a/spec/factories/partner.rb
+++ b/spec/factories/partner.rb
@@ -120,11 +120,11 @@ FactoryBot.define do
     end
 
     trait(:verified) do
-      partner_status { "Verified" }
+      partner_status { "verified" }
     end
 
     trait(:recertification_required) do
-      partner_status { "Recertification Required" }
+      partner_status { "recertification_required" }
     end
 
     trait(:submitted) do

--- a/spec/features/partner_approval_feature_spec.rb
+++ b/spec/features/partner_approval_feature_spec.rb
@@ -11,6 +11,6 @@ describe "Partner approval", type: :feature do
       .to_return(status: 200)
 
     click_link("Submit for Approval")
-    expect(partner.reload.partner_status).to eq("Submitted")
+    expect(partner.reload.partner_status).to eq("submitted")
   end
 end

--- a/spec/features/partner_approval_feature_spec.rb
+++ b/spec/features/partner_approval_feature_spec.rb
@@ -6,8 +6,6 @@ describe "Partner approval", type: :feature do
     sign_in(partner)
     visit "/partners/#{partner.id}"
 
-    page.execute_script("window.scrollTo(0,10000)")
-
     stub_request(:post, "#{ENV["DIAPERBANK_ENDPOINT"]}/approvals/")
       .with(body: { partner: { diaper_partner_id: partner.id } })
       .to_return(status: 200)

--- a/spec/features/partner_approval_feature_spec.rb
+++ b/spec/features/partner_approval_feature_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "Partner approval", type: :feature do
+  scenario "Submit for approval button is present when partner requires recertification", js: true do
+    partner = create(:partner, partner_status: "recertification_required")
+    sign_in(partner)
+    visit "/partners/#{partner.id}"
+
+    page.execute_script("window.scrollTo(0,10000)")
+
+    stub_request(:post, "#{ENV["DIAPERBANK_ENDPOINT"]}/approvals/")
+      .with(body: { partner: { diaper_partner_id: partner.id } })
+      .to_return(status: 200)
+
+    expect { click_link("Submit for Approval") }.to_not raise_error
+    expect(partner.reload.partner_status).to eq("Submitted")
+  end
+end

--- a/spec/features/partner_approval_feature_spec.rb
+++ b/spec/features/partner_approval_feature_spec.rb
@@ -10,7 +10,7 @@ describe "Partner approval", type: :feature do
       .with(body: { partner: { diaper_partner_id: partner.id } })
       .to_return(status: 200)
 
-    expect { click_link("Submit for Approval") }.to_not raise_error
+    click_link("Submit for Approval")
     expect(partner.reload.partner_status).to eq("Submitted")
   end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -132,7 +132,7 @@ describe Partner, type: :model, include_shared: true do
           "X-Api-Key" => ENV["DIAPERBANK_KEY"]
         }
       ).to_return(status: 200, body: "", headers: {})
-      expect { partner.approve_me }.to change { partner.partner_status }.from("pending").to("Submitted")
+      expect { partner.approve_me }.to change { partner.partner_status }.from("pending").to("submitted")
     end
 
     it "posts the diaper partner id" do
@@ -144,7 +144,7 @@ describe Partner, type: :model, include_shared: true do
   describe "verified?" do
     context "partner with a verfied status" do
       it "returns a partner verified status as true" do
-        partner = build(:partner, partner_status: "Verified")
+        partner = build(:partner, partner_status: "verified")
         expect(partner.verified?).to be true
       end
     end
@@ -167,7 +167,7 @@ describe Partner, type: :model, include_shared: true do
   describe "pending?" do
     context "partner with a verfied status" do
       it "returns a partner pending status as false" do
-        partner = build(:partner, partner_status: "Verified")
+        partner = build(:partner, partner_status: "verified")
         expect(partner.pending?).to be false
       end
     end

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -77,12 +77,12 @@ describe "Partners API Requests", type: :request do
 
       it "sets the status to Recertification Required" do
         valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("Recertification Required")
+        expect(partner.reload.partner_status).to eq("recertification_required")
       end
 
       it "shows recertification required status in the response body" do
         valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)["message"]).to eq("Partner status: Recertification Required.")
+        expect(JSON.parse(response.body)["message"]).to eq("Partner status: recertification_required.")
       end
 
       it "emails a notification" do
@@ -101,12 +101,12 @@ describe "Partners API Requests", type: :request do
 
       it "sets the status to Verified" do
         valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("Verified")
+        expect(partner.reload.partner_status).to eq("verified")
       end
 
       it "shows verified status in the response body" do
         valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)["message"]).to eq("Partner status: Verified.")
+        expect(JSON.parse(response.body)["message"]).to eq("Partner status: verified.")
       end
     end
 


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes ("bundle exec rspec")
- Title include "WIP" if work is in progress.

-->

Resolves #001 <!--fill issue number-->

### Description
We had a bug in which the partner approval button was looking for a `partner_status` of `recertification_requested`, but the status was passed inconsistently.

This led to attempting to force an enum of all partner statuses, which is ongoing.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

See new spec: `spec/features/partner_approval_feature_spec.rb`