### PR TITLE
Fix seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 require 'faker'
 
 puts "Creating partners..."
-puts "Adding an 'approved' partner."
-Partner.create(
+puts "Adding an 'approved' partner and user."
+verified_partner = Partner.create(
     executive_director_name: "Leslie Knope",
     program_contact_name: "Leslie Knope",
     name: "Pawnee Parent Service",
@@ -18,10 +18,16 @@ Partner.create(
     executive_director_email: "verified@example.com",
     partner_status: "verified"
 )
+User.create(
+    password: "password",
+    password_confirmation: "password",
+    email: "verified@example.com",
+    partner: verified_partner
+)
 
-puts "Adding a generic 'pending' partner."
+puts "Adding a generic 'pending' partner and user."
 pending_user_name = Faker::Name.name
-Partner.create(
+unverified_partner = Partner.create(
     executive_director_name: pending_user_name,
     program_contact_name: pending_user_name,
     name: "County Diaper Bank",
@@ -34,9 +40,15 @@ Partner.create(
     zips_served: Faker::Address.zip,
     executive_director_email: "unverified@example.com"
 )
+User.create(
+    password: "password",
+    password_confirmation: "password",
+    email: "unverified@example.com",
+    partner: unverified_partner
+)
 
-puts "Adding a 'invited' partner."
-Partner.create(
+puts "Adding an 'invited' partner and user."
+invited_partner_1 = Partner.create(
     partner_status: "invited",
     diaper_bank_id: 1,
     diaper_partner_id: 2,
@@ -52,9 +64,15 @@ Partner.create(
     zips_served: Faker::Address.zip,
     executive_director_email: "anyone@pawneehomelss.com"
 )
+User.create(
+    password: "password",
+    password_confirmation: "password",
+    email: "invited_partner_1@example.com",
+    partner: invited_partner_1
+)
 
-puts "Adding a 'invited' partner."
-Partner.create(
+puts "Adding an 'invited' partner and user."
+invited_partner_2 = Partner.create(
     partner_status: "invited",
     diaper_bank_id: 1,
     diaper_partner_id: 3,
@@ -70,9 +88,16 @@ Partner.create(
     zips_served: Faker::Address.zip,
     executive_director_email: "contactus@pawneepregnancy.com"
 )
+User.create(
+    password: "password",
+    password_confirmation: "password",
+    email: "invited_partner_2@example.com",
+    partner: invited_partner_2
+)
 
-puts "Adding a 'recertification_required' partner."
-Partner.create(
+
+puts "Adding a 'recertification_required' partner and user."
+recertification_required_partner = Partner.create(
     name: "Pawnee Senior Citizens Center",
     partner_status: "recertification_required",
     diaper_bank_id: 1,
@@ -87,6 +112,12 @@ Partner.create(
     website: Faker::Internet.domain_name,
     zips_served: Faker::Address.zip,
     executive_director_email: "help@pscc.org"
+)
+User.create(
+    password: "password",
+    password_confirmation: "password",
+    email: "recertification@example.com",
+    partner: recertification_required_partner
 )
 
 puts "Done creating partners."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,8 +16,6 @@ Partner.create(
     diaper_bank_id: 1,
     diaper_partner_id: 1,
     executive_director_email: "verified@example.com",
-    email: "verified@example.com",
-    password: "password",
     partner_status: "verified"
 )
 
@@ -34,15 +32,11 @@ Partner.create(
     zip_code: Faker::Address.zip,
     website: Faker::Internet.domain_name,
     zips_served: Faker::Address.zip,
-    executive_director_email: "unverified@example.com",
-    email: "unverified@example.com",
-    password: "password"
+    executive_director_email: "unverified@example.com"
 )
 
 puts "Adding a 'invited' partner."
 Partner.create(
-    name: "Pawnee Homeless Shelter",
-    email: "anyone@pawneehomelss.com",
     partner_status: "invited",
     diaper_bank_id: 1,
     diaper_partner_id: 2,
@@ -56,14 +50,11 @@ Partner.create(
     zip_code: Faker::Address.zip,
     website: Faker::Internet.domain_name,
     zips_served: Faker::Address.zip,
-    executive_director_email: "anyone@pawneehomelss.com",
-    password: "password"
+    executive_director_email: "anyone@pawneehomelss.com"
 )
 
 puts "Adding a 'invited' partner."
 Partner.create(
-    name: "Pawnee Pregnancy Center",
-    email: "contactus@pawneepregnancy.com",
     partner_status: "invited",
     diaper_bank_id: 1,
     diaper_partner_id: 3,
@@ -77,20 +68,17 @@ Partner.create(
     zip_code: Faker::Address.zip,
     website: Faker::Internet.domain_name,
     zips_served: Faker::Address.zip,
-    executive_director_email: "contactus@pawneepregnancy.com",
-    password: "password"
+    executive_director_email: "contactus@pawneepregnancy.com"
 )
 
 puts "Adding a 'recertification_required' partner."
 Partner.create(
     name: "Pawnee Senior Citizens Center",
-    email: "help@pscc.org",
     partner_status: "recertification_required",
     diaper_bank_id: 1,
     diaper_partner_id: 5,
     executive_director_name: Faker::Name.name,
     program_contact_name: Faker::Name.name,
-    name: "County Diaper Bank",
     address1: Faker::Address.street_address,
     address2: "",
     city: Faker::Address.city,
@@ -98,8 +86,7 @@ Partner.create(
     zip_code: Faker::Address.zip,
     website: Faker::Internet.domain_name,
     zips_served: Faker::Address.zip,
-    executive_director_email: "help@pscc.org",
-    password: "password"
+    executive_director_email: "help@pscc.org"
 )
 
 puts "Done creating partners."

--- a/spec/lib/tasks/db_seed_spec.rb
+++ b/spec/lib/tasks/db_seed_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+describe "db:seed" do
+  before { Rails.application.load_tasks }
+
+  it { expect { Rake::Task["db:seed"].invoke }.not_to raise_exception }
+end


### PR DESCRIPTION
Resolves #162 

### Description

- No longer references email and password attributes on the Partner model during database seeding
- Cleans up duplicate name attribute

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran `db:seed` task successfully