### PR TITLE
Fixes the issue reported by the cny diaper bank. It seems that on the…

### DIFF
--- a/app/models/family_request.rb
+++ b/app/models/family_request.rb
@@ -26,7 +26,7 @@ class FamilyRequest < ApplicationRecord
 
     {
       organization_id: partner.diaper_bank_id,
-      partner_id: partner_id,
+      partner_id: partner.diaper_partner_id,
       requested_items: requested_items
     }.to_json
   end


### PR DESCRIPTION
… family request we were sending the id of the partner in the partner rather than the diaper_partner_id which is the id it corresponds to on the diaper side.

This is a minor change. We were using the id of the partner, not the `diaper_partner_id` for the family request which was making it seem like requests were coming from incorrect partners.