### PR TITLE
Moved Internal Database Section, Issues #197 & #198

### DIFF
--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -48,7 +48,7 @@
               <% end %>
               </div>
               <div class="form-group row">
-                <label class="control-label col-md-3">Agency Mission</label>
+                <label class="control-label col-md-3">Description of Agency Mission</label>
                 <div class="col-md-8">
                   <%= form.text_area :agency_mission, class: "form-control" %>
                 </div>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -136,6 +136,12 @@
                 </div>
               </div>
               <div class="form-group row">
+                <label class="control-label col-md-3">Internal Database</label>
+                <div class="col-md-8">
+                <%= form.check_box :internal_db, class: "form-check-input form-control" %>
+                </div>
+              </div>
+              <div class="form-group row">
                 <label class="control-label col-md-3">Evidence Based</label>
                 <div class="col-md-8">
                   <%= form.check_box :evidence_based, class: "form-control form-check-input" %>
@@ -352,12 +358,7 @@
                 <%= form.check_box :income_verification, class: "form-check-input form-control" %>
               </div>
             </div>
-            <div class="form-group row">
-              <label class="control-label col-md-3">Internal Database</label>
-              <div class="col-md-8">
-                <%= form.check_box :internal_db, class: "form-check-input form-control" %>
-              </div>
-            </div>
+          
             <div class="form-group row">
               <label class="control-label col-md-3">MAAC Program Participant</label>
               <div class="col-md-8">

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -48,7 +48,7 @@
                     <dd>Documentation not on file</dd>
                   <% end %>
 
-                  <dt>Agency Mission</dt>
+                  <dt>Description of Agency Mission</dt>
                   <dd><%= @partner.agency_mission %></dd>
 
                   <address>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -110,6 +110,9 @@
                   <dt>Case Management</dt>
                   <dd><%= humanize_boolean(@partner.case_management) %></dd>
 
+                  <dt>Internal DB</dt>
+                  <dd><%= humanize_boolean(@partner.internal_db) %></dd>
+
                   <dt>Evidence Based</dt>
                   <dd><%= humanize_boolean(@partner.evidence_based) %></dd>
 
@@ -198,9 +201,6 @@
 
                   <dt>Income Verification</dt>
                   <dd><%= humanize_boolean(@partner.income_verification) %></dd>
-
-                  <dt>Internal DB</dt>
-                  <dd><%= humanize_boolean(@partner.internal_db) %></dd>
 
                   <dt>MAAC</dt>
                   <dd><%= humanize_boolean(@partner.maac) %></dd>


### PR DESCRIPTION
Resolves #197 #198 

### Description

Moved Internal Database section from the Population Served section to the Agency Stability section, before the Evidence Based section. 

This change occurs in `views/partners/_form.html.erb` per #197 and `views/partners/show.html.erb` per #198 

### Type of change

Requested change via Issues to provide greater clarity in the overall form.

### How Has This Been Tested?

Relocation of section. Visual confirmation of relocation.

### Screenshots
<img width="805" alt="Screen Shot 2019-09-12 at 5 10 11 PM" src="https://user-images.githubusercontent.com/49502059/64824632-42842f00-d580-11e9-9ddd-f3f1965df86f.png">

<img width="806" alt="Screen Shot 2019-09-12 at 5 10 19 PM" src="https://user-images.githubusercontent.com/49502059/64824663-5465d200-d580-11e9-9ffc-4178e9518f10.png">
