### PR TITLE
[security] Update devise to 4.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,10 +115,10 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     debug_inspector (0.0.3)
-    devise (4.6.2)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     devise_invitable (1.7.5)


### PR DESCRIPTION
Addresses [CVE-2019-16109]

[CVE-2019-16109]: https://nvd.nist.gov/vuln/detail/CVE-2019-16109