### PR TITLE
[security] Update nokogiri to 1.10.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.1.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
Addresses [CVE-2019-5477]

[CVE-2019-5477]: https://nvd.nist.gov/vuln/detail/CVE-2019-5477