### PR TITLE
[security] Update rubyzip to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
Addresses [CVE-2019-16892]

[CVE-2019-16892]: https://nvd.nist.gov/vuln/detail/CVE-2019-16892