### PR TITLE
Add number of families and children served by partner

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -23,7 +23,7 @@
 class Child < ApplicationRecord
   CAN_LIVE_WITH = %w[Mother Father Grandparent Foster\ Parent Other\ Parent/Relative].freeze
   serialize :child_lives_with, Array
-  belongs_to :family
+  belongs_to :family, counter_cache: true
   has_many :family_request_child, dependent: :destroy
   has_many :family_requests, through: :family_request_child
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -25,7 +25,7 @@
 #
 
 class Family < ApplicationRecord
-  belongs_to :partner
+  belongs_to :partner, counter_cache: true
   has_many :children, dependent: :destroy
   has_many :authorized_family_members, dependent: :destroy
   serialize :sources_of_income, Array

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -159,6 +159,8 @@ class Partner < ApplicationRecord
         serve_income_circumstances: serve_income_circumstances,
         income_verification: income_verification,
         internal_db: internal_db,
+        number_of_families_served: families_count,
+        number_of_children_served: number_of_children_served,
         maac: maac,
         enthnic_composition: {
           african_american: population_black,
@@ -226,6 +228,12 @@ class Partner < ApplicationRecord
 
   def family_request_active?
     ACTIVE_FAMILY_REQUESTS.include?(diaper_bank_id)
+  end
+
+  def number_of_children_served
+    return 0 if families.blank?
+
+    families.map(&:children_count).reduce(:+)
   end
 
   private

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -202,6 +202,12 @@
                   <dt>Income Verification</dt>
                   <dd><%= humanize_boolean(@partner.income_verification) %></dd>
 
+                  <dt>Number of Families Served</dt>
+                  <dd><%= (@partner.families_count) %></dd>
+
+                  <dt>Number of Children Served</dt>
+                  <dd><%= (@partner.number_of_children_served) %></dd>
+
                   <dt>MAAC</dt>
                   <dd><%= humanize_boolean(@partner.maac) %></dd>
 

--- a/db/migrate/20191013193826_add_families_count_to_partners.rb
+++ b/db/migrate/20191013193826_add_families_count_to_partners.rb
@@ -1,0 +1,5 @@
+class AddFamiliesCountToPartners < ActiveRecord::Migration[5.2]
+  def change
+    add_column :partners, :families_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20191014130721_populate_partner_families_count.rb
+++ b/db/migrate/20191014130721_populate_partner_families_count.rb
@@ -1,0 +1,7 @@
+class PopulatePartnerFamiliesCount < ActiveRecord::Migration[5.2]
+  def up
+    Partner.find_each do |partner|
+      Partner.reset_counters(partner.id, :families)
+    end
+  end
+end

--- a/db/migrate/20191015193707_add_children_count_to_families.rb
+++ b/db/migrate/20191015193707_add_children_count_to_families.rb
@@ -1,0 +1,5 @@
+class AddChildrenCountToFamilies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :families, :children_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20191015193830_populate_family_children_count.rb
+++ b/db/migrate/20191015193830_populate_family_children_count.rb
@@ -1,0 +1,7 @@
+class PopulateFamilyChildrenCount < ActiveRecord::Migration[5.2]
+  def up
+    Family.find_each do |family|
+      Family.reset_counters(family.id, :children)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_172501) do
+ActiveRecord::Schema.define(version: 2019_10_15_193830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2019_07_26_172501) do
     t.datetime "updated_at", null: false
     t.bigint "partner_id"
     t.boolean "military", default: false
+    t.integer "children_count", default: 0
     t.index ["partner_id"], name: "index_families_on_partner_id"
   end
 
@@ -211,6 +212,7 @@ ActiveRecord::Schema.define(version: 2019_07_26_172501) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "other_agency_type"
+    t.integer "families_count", default: 0
     t.index ["diaper_bank_id"], name: "index_partners_on_diaper_bank_id"
   end
 

--- a/lib/tasks/counters.rake
+++ b/lib/tasks/counters.rake
@@ -1,0 +1,11 @@
+namespace :counters do
+  task update: :environment do
+    Partner.find_each do |partner|
+      Partner.reset_counters(partner.id, :families)
+    end
+
+    Family.find_each do |family|
+      Family.reset_counters(family.id, :children)
+    end
+  end
+end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -160,6 +160,25 @@ describe Partner, type: :model, include_shared: true do
     end
   end
 
+  describe "number_of_children_served" do
+    let(:partner) { create(:partner) }
+
+    context "when partner does not have any children served" do
+      it "returns 0" do
+        expect(partner.number_of_children_served).to eq(0)
+      end
+    end
+
+    context "when partner have children served" do
+      let(:family) { create(:family, partner_id: partner.id) }
+      let!(:children) { create_list(:child, 5, family_id: family.id) }
+
+      it "returns the number of served children" do
+        expect(partner.number_of_children_served).to eq(5)
+      end
+    end
+  end
+
   describe "export_json" do
     it "returns a hash" do
       partner = build(:partner)


### PR DESCRIPTION
- Add families_count to partner as counter_cache
- Add children_count to family as counter_cache
- Add number_of_children_served to Partner model
- Update partners/show view (add families and children served)
- Add task to update counter cache

Resolves https://github.com/rubyforgood/diaper/issues/1283

# Checklist:

- I have performed a self-review of my own code
- I have added tests that prove that my feature works
- New and existing unit tests pass locally with my changes ("bundle exec rspec")

### Description
This change was requested by https://github.com/rubyforgood/diaper/issues/1283.
The strategy that I chose for this feature was store the families count and the children count using the counter cache rails. Wich consists of create two migrations to add a field and to update the field on the tables Partners and Families. And to keep those fields up to date I also created a task to update those fields.
It's important to say the `zip codes served by this Partner` was already implemented

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* I added an test to partner_spec
* And I tooked a screeshot that shows the new fields on Partner show view

### Screenshots
![partner_show](https://user-images.githubusercontent.com/31258932/66874408-6670d100-ef81-11e9-894f-d8b622725277.jpg)

