### PR TITLE
flip child item request backgorund color

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,3 +46,7 @@
   color: #444444;
   border-top: 1px solid #d2d6de;
 }
+
+tr.row-success {
+  background-color: #d1ecf1;
+}

--- a/app/controllers/child_item_requests_controller.rb
+++ b/app/controllers/child_item_requests_controller.rb
@@ -11,7 +11,10 @@ class ChildItemRequestsController < ApplicationController
           child_name: child_item_request.child.first_name
         )
         render partial: "child_item_requests/child_item_request_update",
-          object: build_open_struct(message)
+          object: build_open_struct(
+            message,
+            picked_up: child_item_request.picked_up
+          )
       end
     end
   end
@@ -75,8 +78,12 @@ class ChildItemRequestsController < ApplicationController
 
   private
 
-  def build_open_struct(message)
-    OpenStruct.new(message: message, item_id: child_item_request.id)
+  def build_open_struct(message, picked_up: false)
+    OpenStruct.new(
+      message: message,
+      item_id: child_item_request.id,
+      picked_up: picked_up
+    )
   end
 
   def child_item_request

--- a/app/views/child_item_requests/_child_item_request_update.js.erb
+++ b/app/views/child_item_requests/_child_item_request_update.js.erb
@@ -11,3 +11,11 @@ $("#flash-message-container-nested-<%= child_item_request_update.item_id %>").pr
     </span>
   </div>
 `)
+
+element_id = "child-item-requests-row-<%= child_item_request_update.item_id %>"
+classList = document.getElementById(element_id).classList
+<% if child_item_request_update.picked_up %>
+    classList.add("row-success")
+<% else %>
+    classList.remove("row-success")
+<% end %>

--- a/app/views/pickup_sheets/show.html.erb
+++ b/app/views/pickup_sheets/show.html.erb
@@ -32,7 +32,7 @@
                   <td colspan="7" id="flash-message-container-nested-<%= child_item_request.id%>">
                   </td>
                 </tr>
-                <tr>
+                <tr id="child-item-requests-row-<%= child_item_request.id%>" class="<%= child_item_request.picked_up? ? 'row-success' : '' %>">
                   <td><%= child.display_name %></td>
                   <td>
                     <%= select_tag :authorized_family_member_id,


### PR DESCRIPTION
Make marking pickup  more intuitive by flipping row background color when pickup is marked as picked up.