### PR TITLE
Document how to run feature specs in headless mode or in the browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,17 @@ Run all the tests with:
 This app uses RSpec, Capybara, and FactoryBot for testing. Make sure the tests run clean & green before submitting a Pull Request. If you are inexperienced in writing tests or get stuck on one, please reach out so one of us can help you. :)
 
 The one situation where you probably don't need to write new tests is when simple re-stylings are done (ie. the page may look slightly different but the Test suite is unaffected by those changes).
+
+##### Feature specs
+
+If you need to see a feature spec run in the browser, you can use the following env variable:
+
+```
+NOT_HEADLESS=true bundle exec rspec
+```
+
+Keep in mind that you need js to be enabled. For example:
+
+```
+describe "PickupSheet", type: :feature, js: true do
+```

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,16 +44,6 @@ ActiveRecord::Migration.maintain_test_schema!
 # If an element is hidden, Capybara should ignore it
 Capybara.ignore_hidden_elements = true
 
-# https://docs.travis-ci.com/user/chrome
-Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu window-size=1680,1050])
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-end
-
-# Enable JS for Capybara tests
-Capybara.javascript_driver = :chrome
-
 Capybara::Screenshot.autosave_on_failure = true
 # The driver name should match the Capybara driver config name.
 Capybara::Screenshot.register_driver(:chrome) do |driver, path|
@@ -78,8 +68,9 @@ Capybara.ignore_hidden_elements = true
 
 # https://docs.travis-ci.com/user/chrome
 Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu window-size=1680,1050])
-
+  args = %w[no-sandbox disable-gpu window-size=1680,1050]
+  args << "headless" unless ENV["NOT_HEADLESS"] == "true"
+  options = Selenium::WebDriver::Chrome::Options.new(args: args)
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 


### PR DESCRIPTION
- Remove duplicate config
- Document how to run specs in the browser