### PR TITLE
Increase families controller test coverage to 100%

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "webmock"
+  gem "rails-controller-testing"
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -442,6 +446,7 @@ DEPENDENCIES
   puma (~> 3.11)
   pundit (~> 2.0.0)
   rails (~> 5.2.1)
+  rails-controller-testing
   rspec-rails (~> 3.5)
   rubocop
   rubocop-rspec

--- a/spec/requests/families_spec.rb
+++ b/spec/requests/families_spec.rb
@@ -24,6 +24,42 @@ RSpec.describe "Families", type: :request do
     end
   end
 
+  describe "GET #show" do
+    let(:family) { create(:family, partner: partner) }
+
+    it "should return status code 200 if a family is found" do
+      get family_path(family.id)
+
+      expect(response).to have_http_status :ok
+    end
+
+    it "should render 404 for a family not found" do
+      max_id = family.id + 1
+
+      get family_path(max_id)
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+
+  describe "GET #edit" do
+    let(:family) { create(:family, partner: partner) }
+
+    it "should render the edit template" do
+      get edit_family_path(family.id)
+
+      expect(response).to render_template(:edit)
+    end
+
+    it "should render 404 for a family not found" do
+      max_id = family.id + 1
+
+      get edit_family_path(max_id)
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+
   describe "POST #create" do
     it "should create and redirect to family_path" do
       post families_path, params: { family: attributes_for(:family) }
@@ -32,6 +68,15 @@ RSpec.describe "Families", type: :request do
 
       expect(response).to redirect_to(family_path(family.id))
       expect(request.flash[:notice]).to eql "Family was successfully created."
+    end
+
+    it "renders :new if the create action does not succeed" do
+      post families_path, params: { family:  { guardian_first_name: nil } }
+
+      family = Family.last
+
+      expect(response).to render_template(:new)
+      expect(family).to be_nil
     end
   end
 
@@ -43,6 +88,14 @@ RSpec.describe "Families", type: :request do
 
       expect(response).to redirect_to(family_path(family.id))
       expect(request.flash[:notice]).to eql "Family was successfully updated."
+    end
+
+    it "renders :edit if the update does not succeed" do
+      put family_path(family), params: { family: { guardian_first_name: nil } }
+
+      expect(response).to have_http_status :ok
+      expect(response).to render_template(:edit)
+      expect(family.guardian_first_name).not_to be_nil
     end
   end
 


### PR DESCRIPTION
#### Description
This increases test coverage to 100% for the families controller. The only trade-off however being that a gem was added in order to be able to use the `render_template` matcher. It seemed to be the most clean way to go about testing the failure cases (i.e. create/update not succeeding)

### Type of change
* Test Suite Only

### How Has This Been Tested?
Running the test suite

### Screenshots
<img width="1647" alt="Screen Shot 2019-10-24 at 7 49 11 PM" src="https://user-images.githubusercontent.com/6576820/67539747-f86e8d00-f697-11e9-8f22-4cd4953da325.png">

