### PR TITLE
Add children info to families show page

### DIFF
--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -83,6 +83,27 @@
         <div class="row">
           <div class="col-12">
             <div class="card mb-4">
+            <h5 class="card-header bg-primary text-white">Children Information</h5>
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Date of birth</th>
+                    <th scope="col">Gender</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @family.children.each do |child| %>
+                    <tr>
+                      <td><%= child.display_name %></td>
+                      <td><%= child.date_of_birth %></td>
+                      <td><%= child.gender %></td>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="card mb-4">
             <h5 class="card-header bg-primary text-white">Authorized Members for Pick Up</h5>
               <table class="table table-striped">
                 <thead>
@@ -100,27 +121,6 @@
                       <td><%= member.last_name %></td>
                       <td><%= member.date_of_birth %></td>
                       <td><%= member.comments %></td>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-
-            <div class="card mb-4">
-            <h5 class="card-header bg-primary text-white">Children Information</h5>
-              <table class="table table-striped">
-                <thead>
-                  <tr>
-                    <th scope="col">Name</th>
-                    <th scope="col">Date of birth</th>
-                    <th scope="col">Gender</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <% @family.children.each do |child| %>
-                    <tr>
-                      <td><%= child.display_name %></td>
-                      <td><%= child.date_of_birth %></td>
-                      <td><%= child.gender %></td>
                   <% end %>
                 </tbody>
               </table>

--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -18,7 +18,7 @@
 
     <div class="row">
       <div class="col-12">
-        <div class="card mb-12">
+        <div class="card mb-4">
           <h5 class="card-header bg-primary text-white">Family Information
             <%= link_to 'Add An Authorized Member To This Family', new_authorized_family_member_path(family_id: @family.id), class: "btn btn-sm btn-warning pull-right", style: "margin-left:10px;" %>
             <%= link_to 'Add Child To This Family', new_child_path(family_id: @family.id), class: "btn btn-sm btn-warning pull-right" %>
@@ -82,7 +82,7 @@
 
         <div class="row">
           <div class="col-12">
-            <div class="card mb-12">
+            <div class="card mb-4">
             <h5 class="card-header bg-primary text-white">Authorized Members for Pick Up</h5>
               <table class="table table-striped">
                 <thead>
@@ -100,6 +100,27 @@
                       <td><%= member.last_name %></td>
                       <td><%= member.date_of_birth %></td>
                       <td><%= member.comments %></td>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="card mb-4">
+            <h5 class="card-header bg-primary text-white">Children Information</h5>
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Date of birth</th>
+                    <th scope="col">Gender</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @family.children.each do |child| %>
+                    <tr>
+                      <td><%= child.display_name %></td>
+                      <td><%= child.date_of_birth %></td>
+                      <td><%= child.gender %></td>
                   <% end %>
                 </tbody>
               </table>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes ("bundle exec rspec")
- Title include "WIP" if work is in progress.

-->

Resolves #250 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

Include anything else we should know about. -->
There was no area for children information on family show page. Also card's were using wrong div class. Changed them to class="card mb-4"

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
Tested by view

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
<img width="1440" alt="Screen Shot 2019-10-25 at 11 11 09" src="https://user-images.githubusercontent.com/10260283/67554567-580c7d00-f718-11e9-9475-9cfd1f5dd06b.png">

