### PR TITLE
Moves the create buttons to the top of the request index

### DIFF
--- a/app/views/partner_requests/index.html.erb
+++ b/app/views/partner_requests/index.html.erb
@@ -15,7 +15,17 @@
       <p><%= notice %><a class="alert-link" href="#"></p>
       </a></p>
     </div>
+    <% end %>
+
+    <div class="actions">
+      <% if @partner.verified? %>
+        <%= link_to 'Create New Bulk Diaper Request', new_partner_request_path, class: 'btn btn-primary' %>
       <% end %>
+      <% if @partner.verified? && Flipper[:family_requests].enabled?(@partner) %>
+        <%= link_to 'Create New Family Diaper Request', new_family_request_path, class: 'btn btn-primary' %>
+      <% end %>
+    </div>
+
     <div class="tile">
       <h3>Diaper Request History</h3>
 
@@ -50,19 +60,6 @@
         <% end %>
         </tbody>
       </table>
-
-      <hr>
-
-      <div class="actions">
-        <% if @partner.verified? %>
-          <%= link_to 'Create New Bulk Diaper Request', new_partner_request_path, class: 'btn btn-primary' %>
-        <% end %>
-        <% if @partner.verified? && Flipper[:family_requests].enabled?(@partner) %>
-          <%= link_to 'Create New Family Diaper Request', new_family_request_path, class: 'btn btn-primary' %>
-        <% end %>
-      </div>
-
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
Sean and I had talked about this at the conference.

I noticed it while demoing the app to some attendees. This PR moves the create new request buttons to the top of the requests #index page.

I wasn't sure how to style it; we don't really have this anywhere else yet. Happy to change it if there's a preferred styling!