### PR TITLE
Api endpoint for diaperbase to add a partner or send a reminder email…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_from: .rubocop_todo.yml
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5.3
+  TargetRubyVersion: 2.6.4
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"
@@ -216,6 +216,10 @@ Metrics/LineLength:
   URISchemes:
   - http
   - https
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Lint/AssignmentInCondition:
   Description: Don't use assignment in conditions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition

--- a/app/controllers/api/v1/add_partners_controller.rb
+++ b/app/controllers/api/v1/add_partners_controller.rb
@@ -1,0 +1,42 @@
+class Api::V1::AddPartnersController < ApiController
+  skip_before_action :verify_authenticity_token
+  respond_to :json
+
+  def create
+    return head :forbidden unless api_key_valid?
+
+    partner = Partner.find_by(diaper_partner_id: partner_params[:diaper_partner_id])
+
+    user = User.find_by(email: partner_params[:email])
+    if user
+      user.send_reset_password_instructions
+    else
+      user = User.invite!(email: partner_params[:email], partner: partner) do |new_user|
+        new_user.message = partner_params[:invitation_text]
+      end
+    end
+
+    render json: {
+      email: user.email,
+             id: partner.id
+    }
+  rescue ActiveRecord::RecordInvalid => e
+    render e.message
+  end
+
+  private
+
+  def api_key_valid?
+    return true if Rails.env.development?
+
+    request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
+  end
+
+  def partner_params
+    params.require(:partner).permit(
+      :diaper_partner_id,
+      :invitation_text,
+      :email
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: "json" } do
     namespace :v1 do
       resources :partners, only: [:create, :show, :update]
-      # resource :partners, only: [:update]
+      resources :add_partners, only: [:create]
     end
   end
 

--- a/spec/requests/api/v1/add_partners_requests_spec.rb
+++ b/spec/requests/api/v1/add_partners_requests_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Partners API Requests", type: :request do
+  describe "POST /api/v1/add_partners" do
+    context "when given valid parameters" do
+      it "creates a new user record" do
+        expect { valid_add_partner_creation_request }
+          .to change { User.count }
+          .from(0)
+          .to(1)
+      end
+      it "doesn't creates a new user if it exists" do
+        FactoryBot.create(:user, email: "test@example.com")
+        expect { valid_add_partner_creation_request }
+          .to_not change { User.count }
+      end
+    end
+  end
+
+  def valid_add_partner_creation_request(
+      email: "test@example.com",
+      diaper_partner_id: "diaper-partner-id"
+    )
+    post api_v1_add_partners_path(
+      partner: {
+        email: email,
+          diaper_partner_id: diaper_partner_id
+      }
+    )
+  end
+end


### PR DESCRIPTION
This is the companion part of issue @1282 on the diaper app (https://github.com/rubyforgood/diaper/issues/1282) that allows diaper banks to reset the password or add another user to partner system. It required #222 be finished.