### PR TITLE
Add margin top to filters buttons in children index

### DIFF
--- a/app/views/children/index.html.erb
+++ b/app/views/children/index.html.erb
@@ -20,7 +20,7 @@
             <%= collection_select(:filters, :from_children, @children || {}, :id, :first_name, { include_blank: true, selected: @selected_children_first_name }, class: "form-control") %>
           </div>
         <% end %>
-        <div class="col-xs-12 col-sm-6">
+        <div class="col-xs-12 col-sm-6 mt-3">
           <%= filter_button %>
           <%= cancel_button_to children_path %>
         </div><!-- /.row -->


### PR DESCRIPTION
Resolves #282  <!--fill issue number-->

### Description

* Just add bootstrap class to add margin top

### Type of change

* This change does not requires a documentation update
* Style change

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
BEFORE:
![before_the_change](https://user-images.githubusercontent.com/31258932/78843472-432b5980-79d9-11ea-877d-bbcd80c764ab.jpg)

AFTER:
![after_the_change](https://user-images.githubusercontent.com/31258932/78843483-4a526780-79d9-11ea-84e3-d3f6b2eb58bc.jpg)

