### PR TITLE
Set Invitation reply_to to organzation email that invited the partner

### DIFF
--- a/app/controllers/api/v1/add_partners_controller.rb
+++ b/app/controllers/api/v1/add_partners_controller.rb
@@ -13,6 +13,7 @@ class Api::V1::AddPartnersController < ApiController
     else
       user = User.invite!(email: partner_params[:email], partner: partner) do |new_user|
         new_user.message = partner_params[:invitation_text]
+        new_user.invitation_reply_to = partner_params[:organization_email]
       end
     end
 
@@ -36,6 +37,7 @@ class Api::V1::AddPartnersController < ApiController
     params.require(:partner).permit(
       :diaper_partner_id,
       :invitation_text,
+      :organization_email,
       :email
     )
   end

--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::PartnersController < ApiController
 
     user = User.invite!(email: partner_params[:email], partner: partner) do |new_user|
       new_user.message = partner_params[:invitation_text]
+      new_user.invitation_reply_to = partner_params[:organization_email]
     end
 
     render json: {
@@ -69,6 +70,7 @@ class Api::V1::PartnersController < ApiController
       :diaper_bank_id,
       :diaper_partner_id,
       :invitation_text,
+      :organization_email,
       :email,
       :status
     )

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,0 +1,21 @@
+class CustomDeviseMailer < Devise::Mailer
+  # Implemented to enable us to configure emails more.
+  #
+  # For example, we want to set `reply-to` to corresponding
+  # organization emails of partners rather than a globally
+  # set one for invitation emails.
+  #
+  # Following the suggestion of -
+  # https://github.com/heartcombo/devise/wiki/How-To:-Use-custom-mailer
+  #
+
+  helper :application # gives access to all helpers defined within `application_helper`.
+  include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  default template_path: 'devise/mailer' # to make sure that your mailer uses the devise views
+
+  #
+  # Set the reply_to to attr `invitation_reply_to` on User otherwise fallback to
+  # the email address of the default sender.
+  #
+  default reply_to: ->(x) { x&.resource&.invitation_reply_to || DEVISE_DEFAULT_MAIL_SENDER }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  attr_accessor :message
+  attr_accessor :message, :invitation_reply_to
+
   belongs_to :partner
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+DEVISE_DEFAULT_MAIL_SENDER = 'accounts@diaper.app'.freeze
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -18,10 +20,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'accounts@diaper.app'
+  config.mailer_sender = DEVISE_DEFAULT_MAIL_SENDER
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'CustomDeviseMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/partner/issues/290

## Description
We want to be able to set the `reply_to` field of Invitation emails to the organization's email instead of the generic `accounts@diaper.app` email. This way organizations can service issues presented by partners quicker without engineering intervention.

This PR accepts the `organization_email` contained in API requests (added in https://github.com/rubyforgood/diaper/pull/1610) and sets the reply_to to that field. The way this PR does it is by adding a custom devise mailer that can set the `reply_to` to the attr on User called `invitation_reply_to`.

- Add CustomDeviseMailer to change `reply_to`
- Add `invitation_reply_to` to User
- Modify API endpoint to utilize the `organization_email` provided.

**Blocked by https://github.com/rubyforgood/diaper/pull/1674**

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested it when hooked up with both partner and diaper.

### Screenshots
Testing with diaper and partner (notice the reply_to)

<img width="1122" alt="Screen Shot 2020-05-16 at 4 13 59 PM" src="https://user-images.githubusercontent.com/11335191/82130506-968b8700-9791-11ea-92cf-d49ba1dc92a5.png">

<img width="1086" alt="Screen Shot 2020-05-16 at 4 13 52 PM" src="https://user-images.githubusercontent.com/11335191/82130505-955a5a00-9791-11ea-9fbc-b6462877572e.png">
