### PR TITLE
Store the value of unaltered partner status

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -40,6 +40,8 @@ class Api::V1::PartnersController < ApiController
       partner.update(partner_status: "pending")
     end
 
+    partner.update(status_in_diaper_base: partner_params[:status])
+
     render json: { message: "Partner status: #{partner.partner_status}." }, status: :ok
   rescue ActiveRecord::RecordNotFound => e
     render e.message

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -64,6 +64,11 @@ describe "Partners API Requests", type: :request do
         valid_partner_update_request(params, headers)
         expect(partner.reload.partner_status).to eq("pending")
       end
+
+      it "sets the unaltered status in diaper base" do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.status_in_diaper_base).to eq("pending")
+      end
     end
 
     context "when we set the partner to recertification_required" do
@@ -91,6 +96,11 @@ describe "Partners API Requests", type: :request do
         valid_partner_update_request(params, headers)
         expect(RecertificationMailer).to have_received(:notice_email).with(user)
       end
+
+      it "sets the unaltered status in diaper base" do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.status_in_diaper_base).to eq("recertification_required")
+      end
     end
 
     context "when we set the partner to approved" do
@@ -111,6 +121,11 @@ describe "Partners API Requests", type: :request do
         valid_partner_update_request(params, headers)
         expect(JSON.parse(response.body)["message"]).to eq("Partner status: verified.")
       end
+
+      it "sets the unaltered status in diaper base" do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.status_in_diaper_base).to eq("approved")
+      end
     end
 
     context "when we try to set the partner to blarg" do
@@ -130,6 +145,11 @@ describe "Partners API Requests", type: :request do
       it "shows pending status in the response body" do
         valid_partner_update_request(params, headers)
         expect(JSON.parse(response.body)["message"]).to eq("Partner status: pending.")
+      end
+
+      it "sets the unlatered status in diaper base" do
+        valid_partner_update_request(params, headers)
+        expect(partner.reload.status_in_diaper_base).to eq("blarg")
       end
     end
   end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes ("bundle exec rspec")
- Title include "WIP" if work is in progress.

-->

Resolves #319 

### Description
Store the received unaltered status of the partner in the API controller `update` in `app/controllers/api/v1/partners_controller.rb`

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Feature

### How Has This Been Tested?

Running tests with rspec

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
