### PR TITLE
Properly seed ChildItemRequest from db/seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -122,7 +122,7 @@ PartnerRequest.all.each do |pr|
     if pr.for_families
         pr.item_requests.each do |request|
             ChildItemRequest.create(
-                child_id: Child.all.sample,
+                child_id: Child.all.sample.id,
                 item_request: request,
                 picked_up: Faker::Boolean.boolean,
                 quantity_picked_up: Faker::Number.within(range: 10..30),


### PR DESCRIPTION
### Description
I noticed that when trying to seed my database with `ChildItemRequest` the section to create them in the seed file fails silently. With a closer look I noticed that this validation error occurs:
```
ActiveRecord::RecordInvalid: Validation failed: Child must exist
from /Users/edwinmak/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.1/lib/active_record/validations.rb:80:in `raise_validation_erro
``` 

A simple fix is to add `.id` to the `Child.all.sample` as shown in the PR.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran it locally before and after
