### PR TITLE
Properly fetch valid item name in child#show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,11 @@ class ApplicationController < ActionController::Base
     @valid_items ||= DiaperBankClient.get_available_items(current_partner.diaper_bank_id)
   end
 
+  helper_method :fetch_valid_item
+  def fetch_valid_item(id)
+    valid_items.find { |vi| vi["id"] == id }
+  end
+
   helper_method :item_id_to_display_string_map
   def item_id_to_display_string_map
     @item_id_to_display_string_map ||= valid_items.each_with_object({}) do |item, hash|

--- a/app/views/children/show.html.erb
+++ b/app/views/children/show.html.erb
@@ -88,7 +88,7 @@
                         <tr>
                           <td><b><%= child_item_request.created_at.to_date.iso8601 %></b>
                           </th>
-                          <td><%= valid_items.dig(child_item_request.ordered_item_diaperid, 'name').to_s %></th>
+                          <td><%= fetch_valid_item(child_item_request.ordered_item_diaperid)&.dig('name')&.to_s %></th>
                           <td><b>
                             <% if (diaperid = child_item_request.picked_up_item_diaperid) && child_item_request.picked_up? %>
                               <%= valid_items.dig(diaperid, 'name') %>

--- a/spec/features/child_feature_spec.rb
+++ b/spec/features/child_feature_spec.rb
@@ -82,7 +82,7 @@ describe Child, type: :feature, include_shared: true, js: true do
       within "tbody" do
         within find("tr:nth-child(1)") do
           expect(find("td:nth-child(1)")).to have_text(Time.zone.today.iso8601)
-          expect(find("td:nth-child(2)")).to have_text("Fantastic diaper")
+          expect(find("td:nth-child(2)")).to have_text("Magic diaper")
           expect(find("td:nth-child(3)")).to have_text("Not picked up")
           expect(find("td:nth-child(4)")).to have_text("100")
           expect(find("td:nth-child(5)")).to have_text("Not picked up")


### PR DESCRIPTION
Resolves #329

### Description
I noticed that the use of `.dig` to retrieve the item name from `valid_items` in the `child#show` template was pulling the wrong record. The format of `valid_items` is an array of hashes so the correct approach should be the `find` and then retrieve the name.

Format of `valid_items`:
```
[{"id"=>11, "partner_key"=>"k_preemie", "name"=>"Kids (Preemie)"},
 {"id"=>13, "partner_key"=>"k_size2", "name"=>"Kids (Size 2)"},
 {"id"=>18, "partner_key"=>"k_size7", "name"=>"Kids (Size 7)"},
 {"id"=>19, "partner_key"=>"k_lxl", "name"=>"Kids L/XL (60-125 lbs)"},
 {"id"=>20, "partner_key"=>"pullup_23t", "name"=>"Kids Pull-Ups (2T-3T)"},
 {"id"=>21, "partner_key"=>"pullup_34t", "name"=>"Kids Pull-Ups (3T-4T)"},
 {"id"=>23, "partner_key"=>"k_sm", "name"=>"Kids S/M (38-65 lbs)"},
 {"id"=>24, "partner_key"=>"swimmers", "name"=>"Swimmers"}
....
```

This PR modifies it so that we match the "id" with the `ordered_item_diaperid` and then extract the name. It does this by adding a new helper method `fetch_valid_item`

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Testing locally
