### PR TITLE
Add API key tests to API requests specs and rejects requests if env var not set

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+DIAPER_KEY="testapikey"

--- a/app/controllers/api/v1/add_partners_controller.rb
+++ b/app/controllers/api/v1/add_partners_controller.rb
@@ -27,12 +27,6 @@ class Api::V1::AddPartnersController < ApiController
 
   private
 
-  def api_key_valid?
-    return true if Rails.env.development?
-
-    request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
-  end
-
   def partner_params
     params.require(:partner).permit(
       :diaper_partner_id,

--- a/app/controllers/api/v1/partner_forms_controller.rb
+++ b/app/controllers/api/v1/partner_forms_controller.rb
@@ -20,12 +20,6 @@ class Api::V1::PartnerFormsController < ApiController
 
   private
 
-  def api_key_valid?
-    return true if Rails.env.development?
-
-    request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
-  end
-
   def partner_form_params
     params.require(:partner_form).permit(
       :diaper_bank_id,

--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -61,12 +61,6 @@ class Api::V1::PartnersController < ApiController
 
   private
 
-  def api_key_valid?
-    return true if Rails.env.development?
-
-    request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
-  end
-
   def partner_params
     params.require(:partner).permit(
       :diaper_bank_id,

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -14,5 +14,11 @@ class ApiController < ApplicationController
     request.format = :json
   end
 
+  def api_key_valid?
+    return true if Rails.env.development?
+
+    request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
+  end
+
   def authenticate; end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -17,6 +17,11 @@ class ApiController < ApplicationController
   def api_key_valid?
     return true if Rails.env.development?
 
+    # This prevents a scenario where an unauthorized request would be allowed access if
+    # both the environment variable is nil (not set) and the request header is missing,
+    # also nil as both would positively match on nil values
+    return false if ENV["DIAPER_KEY"].blank?
+
     request.headers["X-Api-Key"] == ENV["DIAPER_KEY"]
   end
 

--- a/spec/requests/api/v1/add_partners_requests_spec.rb
+++ b/spec/requests/api/v1/add_partners_requests_spec.rb
@@ -34,6 +34,22 @@ describe "Partners API Requests", type: :request do
     end
   end
 
+  describe "Environment variable not set" do
+    it "responds with forbidden" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("DIAPER_KEY").and_return(nil)
+
+      post api_v1_add_partners_path(
+        partner: {
+          email: "test@example.com",
+          diaper_partner_id: "diaper-partner-id"
+        }
+      ), headers: { 'X-Api-Key': nil }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   def valid_add_partner_creation_request(
     email: "test@example.com",
     diaper_partner_id: "diaper-partner-id"

--- a/spec/requests/api/v1/add_partners_requests_spec.rb
+++ b/spec/requests/api/v1/add_partners_requests_spec.rb
@@ -26,6 +26,7 @@ describe "Partners API Requests", type: :request do
         email: email,
         diaper_partner_id: diaper_partner_id
       }
-    )
+    ),
+    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 end

--- a/spec/requests/api/v1/add_partners_requests_spec.rb
+++ b/spec/requests/api/v1/add_partners_requests_spec.rb
@@ -2,17 +2,34 @@ require "rails_helper"
 
 describe "Partners API Requests", type: :request do
   describe "POST /api/v1/add_partners" do
-    context "when given valid parameters" do
-      it "creates a new user record" do
-        expect { valid_add_partner_creation_request }
-          .to change { User.count }
-          .from(0)
-          .to(1)
+    context "with valid API key" do
+      context "when given valid parameters" do
+        it "creates a new user record" do
+          expect { valid_add_partner_creation_request }
+            .to change { User.count }
+            .from(0)
+            .to(1)
+        end
+        it "doesn't creates a new user if it exists" do
+          FactoryBot.create(:user, email: "test@example.com")
+          expect { valid_add_partner_creation_request }
+            .to_not change { User.count }
+        end
       end
-      it "doesn't creates a new user if it exists" do
-        FactoryBot.create(:user, email: "test@example.com")
-        expect { valid_add_partner_creation_request }
-          .to_not change { User.count }
+    end
+
+    context "with invalid API key" do
+      it "responds with forbidden" do
+        expect do
+          post api_v1_add_partners_path(
+            partner: {
+              email: "test@example.com",
+              diaper_partner_id: "diaper-partner-id"
+            }
+          ), headers: { 'X-Api-Key': "INVALID" }
+        end.to_not change { User.count }
+
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/v1/add_partners_requests_spec.rb
+++ b/spec/requests/api/v1/add_partners_requests_spec.rb
@@ -26,7 +26,6 @@ describe "Partners API Requests", type: :request do
         email: email,
         diaper_partner_id: diaper_partner_id
       }
-    ),
-    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    ), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 end

--- a/spec/requests/api/v1/partner_forms_requests_spec.rb
+++ b/spec/requests/api/v1/partner_forms_requests_spec.rb
@@ -43,6 +43,22 @@ describe "Partners API Requests", type: :request do
     end
   end
 
+  describe "Environment variable not set" do
+    it "responds with forbidden" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("DIAPER_KEY").and_return(nil)
+
+      post api_v1_partner_forms_path(
+        partner_form: {
+          diaper_bank_id: 1,
+          sections: %w(section1 section2 section3)
+        }
+      ), headers: { 'X-Api-Key': nil }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   def valid_partner_form_creation_request(
     diaper_bank_id: 1,
     sections: %w(section1 section2 section3)

--- a/spec/requests/api/v1/partner_forms_requests_spec.rb
+++ b/spec/requests/api/v1/partner_forms_requests_spec.rb
@@ -2,26 +2,43 @@ require "rails_helper"
 
 describe "Partners API Requests", type: :request do
   describe "POST /api/v1/partners" do
-    context "when the body is empty" do
-      it "responds with an error status code" do
-        post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    context "with valid API key" do
+      context "when the body is empty" do
+        it "responds with an error status code" do
+          post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
-        expect(response).to have_http_status(:bad_request)
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context "when given valid parameters" do
+        it "responds with an :ok status" do
+          valid_partner_form_creation_request
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "creates a new `PartnerForm` record" do
+          expect { valid_partner_form_creation_request }
+            .to change { PartnerForm.count }
+            .from(0)
+            .to(1)
+        end
       end
     end
 
-    context "when given valid parameters" do
-      it "responds with an :ok status" do
-        valid_partner_form_creation_request
+    context "with invalid API key" do
+      it "responds with forbidden" do
+        expect do
+          post api_v1_partner_forms_path(
+            partner_form: {
+              diaper_bank_id: 1,
+              sections: %w(section1 section2 section3)
+            }
+          ), headers: { 'X-Api-Key': "INVALID" }
+        end.to_not change { PartnerForm.count }
 
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "creates a new `PartnerForm` record" do
-        expect { valid_partner_form_creation_request }
-          .to change { PartnerForm.count }
-          .from(0)
-          .to(1)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/api/v1/partner_forms_requests_spec.rb
+++ b/spec/requests/api/v1/partner_forms_requests_spec.rb
@@ -4,7 +4,7 @@ describe "Partners API Requests", type: :request do
   describe "POST /api/v1/partners" do
     context "when the body is empty" do
       it "responds with an error status code" do
-        post api_v1_partners_path({})
+        post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
         expect(response).to have_http_status(:bad_request)
       end
@@ -35,6 +35,7 @@ describe "Partners API Requests", type: :request do
         diaper_bank_id: diaper_bank_id,
         sections: sections
       }
-    )
+    ),
+    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 end

--- a/spec/requests/api/v1/partner_forms_requests_spec.rb
+++ b/spec/requests/api/v1/partner_forms_requests_spec.rb
@@ -35,7 +35,6 @@ describe "Partners API Requests", type: :request do
         diaper_bank_id: diaper_bank_id,
         sections: sections
       }
-    ),
-    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    ), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 end

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -4,152 +4,191 @@ describe "Partners API Requests", type: :request do
   describe "GET /api/v1/partners/1" do
     let(:partner) { create(:partner) }
 
-    it "returns json for the partner" do
-      get api_v1_partner_path(partner), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    context "with valid API key" do
+      it "returns json for the partner" do
+        get api_v1_partner_path(partner), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
-      expect(response).to have_http_status(:ok)
-      result = JSON.parse(response.body)
-      expect(result["agency"]).to be_present
+        expect(response).to have_http_status(:ok)
+        result = JSON.parse(response.body)
+        expect(result["agency"]).to be_present
+      end
+    end
+
+    context "with invalid API key" do
+      it "should respond with forbidden" do
+        get api_v1_partner_path(partner), headers: { 'X-Api-Key': "INVALID" }
+
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 
   describe "POST /api/v1/partners" do
-    context "when the body is empty" do
-      it "responds with an error status code" do
-        post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    context "with valid API key" do
+      context "when the body is empty" do
+        it "responds with an error status code" do
+          post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
-        expect(response).to have_http_status(:bad_request)
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context "when given valid parameters" do
+        it "responds with an :ok status" do
+          valid_partner_creation_request
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "creates a new `Partner` record" do
+          expect { valid_partner_creation_request }
+            .to change { Partner.count }
+            .from(0)
+            .to(1)
+        end
+
+        it "responds with the `id` and `email` of the new record" do
+          valid_partner_creation_request(email: "new.partner@example.com")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key("id")
+          expect(result).to have_key("email")
+          expect(result["email"]).to eq("new.partner@example.com")
+        end
       end
     end
 
-    context "when given valid parameters" do
-      it "responds with an :ok status" do
-        valid_partner_creation_request
+    context "with invalid API key" do
+      it "should respond with forbidden" do
+        post api_v1_partners_path(
+          partner: {
+            email: "test@example.com",
+            diaper_bank_id: "diaper-bank-id",
+            diaper_partner_id: "diaper-partner-id"
+          }
+        ), headers: { 'X-Api-Key': "INVALID" }
 
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "creates a new `Partner` record" do
-        expect { valid_partner_creation_request }
-          .to change { Partner.count }
-          .from(0)
-          .to(1)
-      end
-
-      it "responds with the `id` and `email` of the new record" do
-        valid_partner_creation_request(email: "new.partner@example.com")
-
-        result = JSON.parse(response.body)
-
-        expect(result).to have_key("id")
-        expect(result).to have_key("email")
-        expect(result["email"]).to eq("new.partner@example.com")
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
   describe "PUT /api/v1/partners" do
-    let(:headers) { { 'X-Api-Key': ENV["DIAPER_KEY"] } }
+    context "with valid API key" do
+      let(:headers) { { 'X-Api-Key': ENV["DIAPER_KEY"] } }
 
-    context "when we set the partner to pending" do
-      let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "pending" } } }
+      context "when we set the partner to pending" do
+        let(:partner) { create(:partner) }
+        let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "pending" } } }
 
-      it "returns OK" do
-        valid_partner_update_request(params, headers)
-        expect(response).to have_http_status(:ok)
+        it "returns OK" do
+          valid_partner_update_request(params, headers)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "sets the status to pending" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.partner_status).to eq("pending")
+        end
+
+        it "sets the unaltered status in diaper base" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.status_in_diaper_base).to eq("pending")
+        end
       end
 
-      it "sets the status to pending" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("pending")
+      context "when we set the partner to recertification_required" do
+        let(:partner) { create(:partner) }
+        let(:user) { create(:user, partner: partner) }
+        let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "recertification_required" } } }
+
+        it "returns OK" do
+          valid_partner_update_request(params, headers)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "sets the status to Recertification Required" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.partner_status).to eq("recertification_required")
+        end
+
+        it "shows recertification required status in the response body" do
+          valid_partner_update_request(params, headers)
+          expect(JSON.parse(response.body)["message"]).to eq("Partner status: recertification_required.")
+        end
+
+        it "emails a notification" do
+          allow(RecertificationMailer).to receive(:notice_email).with(user)
+          valid_partner_update_request(params, headers)
+          expect(RecertificationMailer).to have_received(:notice_email).with(user)
+        end
+
+        it "sets the unaltered status in diaper base" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.status_in_diaper_base).to eq("recertification_required")
+        end
       end
 
-      it "sets the unaltered status in diaper base" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.status_in_diaper_base).to eq("pending")
+      context "when we set the partner to approved" do
+        let(:partner) { create(:partner) }
+        let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "approved" } } }
+
+        it "returns OK" do
+          valid_partner_update_request(params, headers)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "sets the status to Verified" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.partner_status).to eq("verified")
+        end
+
+        it "shows verified status in the response body" do
+          valid_partner_update_request(params, headers)
+          expect(JSON.parse(response.body)["message"]).to eq("Partner status: verified.")
+        end
+
+        it "sets the unaltered status in diaper base" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.status_in_diaper_base).to eq("approved")
+        end
+      end
+
+      context "when we try to set the partner to blarg" do
+        let(:partner) { create(:partner) }
+        let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" } } }
+
+        it "returns OK" do
+          valid_partner_update_request(params, headers)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "sets the status to pending" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.partner_status).to eq("pending")
+        end
+
+        it "shows pending status in the response body" do
+          valid_partner_update_request(params, headers)
+          expect(JSON.parse(response.body)["message"]).to eq("Partner status: pending.")
+        end
+
+        it "sets the unlatered status in diaper base" do
+          valid_partner_update_request(params, headers)
+          expect(partner.reload.status_in_diaper_base).to eq("blarg")
+        end
       end
     end
 
-    context "when we set the partner to recertification_required" do
-      let(:partner) { create(:partner) }
-      let(:user) { create(:user, partner: partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "recertification_required" } } }
+    context "with invalid API key" do
+      it "should respond with forbidden" do
+        partner = create(:partner)
+        params = { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" } }
 
-      it "returns OK" do
-        valid_partner_update_request(params, headers)
-        expect(response).to have_http_status(:ok)
-      end
+        put "/api/v1/partners/1", params: params, headers: { 'X-Api-Key': "INVALID" }, as: :json
 
-      it "sets the status to Recertification Required" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("recertification_required")
-      end
-
-      it "shows recertification required status in the response body" do
-        valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)["message"]).to eq("Partner status: recertification_required.")
-      end
-
-      it "emails a notification" do
-        allow(RecertificationMailer).to receive(:notice_email).with(user)
-        valid_partner_update_request(params, headers)
-        expect(RecertificationMailer).to have_received(:notice_email).with(user)
-      end
-
-      it "sets the unaltered status in diaper base" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.status_in_diaper_base).to eq("recertification_required")
-      end
-    end
-
-    context "when we set the partner to approved" do
-      let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "approved" } } }
-
-      it "returns OK" do
-        valid_partner_update_request(params, headers)
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "sets the status to Verified" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("verified")
-      end
-
-      it "shows verified status in the response body" do
-        valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)["message"]).to eq("Partner status: verified.")
-      end
-
-      it "sets the unaltered status in diaper base" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.status_in_diaper_base).to eq("approved")
-      end
-    end
-
-    context "when we try to set the partner to blarg" do
-      let(:partner) { create(:partner) }
-      let(:params) { { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" } } }
-
-      it "returns OK" do
-        valid_partner_update_request(params, headers)
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "sets the status to pending" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.partner_status).to eq("pending")
-      end
-
-      it "shows pending status in the response body" do
-        valid_partner_update_request(params, headers)
-        expect(JSON.parse(response.body)["message"]).to eq("Partner status: pending.")
-      end
-
-      it "sets the unlatered status in diaper base" do
-        valid_partner_update_request(params, headers)
-        expect(partner.reload.status_in_diaper_base).to eq("blarg")
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -165,8 +204,7 @@ describe "Partners API Requests", type: :request do
         diaper_bank_id: diaper_bank_id,
         diaper_partner_id: diaper_partner_id
       }
-    ),
-    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+    ), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 
   def valid_partner_update_request(params, headers = {})

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -5,7 +5,7 @@ describe "Partners API Requests", type: :request do
     let(:partner) { create(:partner) }
 
     it "returns json for the partner" do
-      get api_v1_partner_path(partner)
+      get api_v1_partner_path(partner), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
       expect(response).to have_http_status(:ok)
       result = JSON.parse(response.body)
@@ -16,7 +16,7 @@ describe "Partners API Requests", type: :request do
   describe "POST /api/v1/partners" do
     context "when the body is empty" do
       it "responds with an error status code" do
-        post api_v1_partners_path({})
+        post api_v1_partners_path({}), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
 
         expect(response).to have_http_status(:bad_request)
       end
@@ -165,7 +165,8 @@ describe "Partners API Requests", type: :request do
         diaper_bank_id: diaper_bank_id,
         diaper_partner_id: diaper_partner_id
       }
-    )
+    ),
+    headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
   end
 
   def valid_partner_update_request(params, headers = {})

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -15,7 +15,7 @@ describe "Partners API Requests", type: :request do
     end
 
     context "with invalid API key" do
-      it "should respond with forbidden" do
+      it "responds with forbidden" do
         get api_v1_partner_path(partner), headers: { 'X-Api-Key': "INVALID" }
 
         expect(response).to have_http_status(:forbidden)
@@ -60,7 +60,7 @@ describe "Partners API Requests", type: :request do
     end
 
     context "with invalid API key" do
-      it "should respond with forbidden" do
+      it "responds with forbidden" do
         post api_v1_partners_path(
           partner: {
             email: "test@example.com",
@@ -182,7 +182,7 @@ describe "Partners API Requests", type: :request do
     end
 
     context "with invalid API key" do
-      it "should respond with forbidden" do
+      it "responds with forbidden" do
         partner = create(:partner)
         params = { partner: { diaper_partner_id: partner.diaper_bank_id, status: "blarg" } }
 

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -193,6 +193,19 @@ describe "Partners API Requests", type: :request do
     end
   end
 
+  describe "Environment variable not set" do
+    it "responds with forbidden" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("DIAPER_KEY").and_return(nil)
+
+      partner = create(:partner)
+
+      get api_v1_partner_path(partner), headers: { 'X-Api-Key': nil }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   def valid_partner_creation_request(
     email: "test@example.com",
     diaper_bank_id: "diaper-bank-id",


### PR DESCRIPTION
Resolves #99 

### Description

- Adds tests to all V1 API request specs to assert:
  + 403 is returned when an invalid API key is used
  + 403 is returned when the `DIAPER_KEY` environment variable is not set
- Moves the `api_key_valid?` method to the parent `ApiController`
- Rejects API requests if the `DIAPER_KEY` environment variable is not set

### Type of change

* Breaking change if `DIAPER_KEY` environment variable is not set in production

### How Has This Been Tested?

- Add automated tests to reflect each change