### PR TITLE
Display unique areas served zip codes on partner dashboard

### DIFF
--- a/app/views/dashboard/_family_details.html.erb
+++ b/app/views/dashboard/_family_details.html.erb
@@ -29,7 +29,7 @@
         <div class="card col-lg-6 dashboard">
           <div class="card-body">
             <h2 class="card-text display-4 zip" data-test="zip-codes">
-              <%= @families.map { |family| "#{family.guardian_zip_code}" }.uniq.join(", ") %>
+              <%= @families.pluck(:guardian_zip_code).uniq.join(", ") %>
             </h2>
           </div>
           <div class="card-footer text-right">

--- a/app/views/dashboard/_family_details.html.erb
+++ b/app/views/dashboard/_family_details.html.erb
@@ -28,7 +28,9 @@
         </div>
         <div class="card col-lg-6 dashboard">
           <div class="card-body">
-            <h2 class="card-text display-4 zip"><%= @families.map {|family| "#{family.guardian_zip_code}"}.join(", ") %></h2>
+            <h2 class="card-text display-4 zip" data-test="zip-codes">
+              <%= @families.map { |family| "#{family.guardian_zip_code}" }.uniq.join(", ") %>
+            </h2>
           </div>
           <div class="card-footer text-right">
             <h5>Areas Served</h5>

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "Dashboard index", type: :feature do
+  let(:duplicated_zip_code) { 33_302 }
+  let(:partner) { create(:partner, :verified) }
+  let(:user) { create(:user, partner: partner) }
+  let!(:family_one) { create(:family, partner: partner, guardian_zip_code: duplicated_zip_code) }
+  let!(:family_two) { create(:family, partner: partner, guardian_zip_code: duplicated_zip_code) }
+
+  scenario "Partner sees only unique guardian zipcodes" do
+    sign_in(user)
+    visit(root_path)
+
+    zip_code_values = find("[data-test='zip-codes']").text.split(", ").map(&:to_i)
+
+    expect(zip_code_values).to eq([duplicated_zip_code])
+  end
+end


### PR DESCRIPTION
Resolves #344 

### Description

- Ensures only unique "Areas Served" zip codes are displayed on the dashboard

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Introduced a `dashboard_feature_spec`
