### PR TITLE
Trigger raise in partners#show instead of accessing nil error

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::PartnersController < ApiController
   def show
     return head :forbidden unless api_key_valid?
 
-    partner = Partner.find_by(diaper_partner_id: params[:id])
+    partner = Partner.find_by!(diaper_partner_id: params[:id])
 
     if params[:impact_metrics]
       render json: { agency: partner.impact_metrics }

--- a/spec/requests/api/v1/partners_requests_spec.rb
+++ b/spec/requests/api/v1/partners_requests_spec.rb
@@ -4,6 +4,19 @@ describe "Partners API Requests", type: :request do
   describe "GET /api/v1/partners/1" do
     let(:partner) { create(:partner) }
 
+    context 'when trying to retrieve data non existent partner' do
+      let(:nonexistent_partner_id) { 0 }
+
+      before do
+        expect(Partner.find_by(diaper_partner_id: nonexistent_partner_id)).to eq(nil)
+      end
+
+      it "respond with not_found" do
+        get api_v1_partner_path(id: nonexistent_partner_id), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context "with valid API key" do
       it "returns json for the partner" do
         get api_v1_partner_path(partner), headers: { 'X-Api-Key': ENV["DIAPER_KEY"] }


### PR DESCRIPTION
### Description
This PR prevents raising an error due to trying to access a method on `nil` if the id provided to partners#show doesn't match any partner. Instead this PR will raise an error early and also return status code `not_found` if there is no `Partner` that matches the id provided.

I discovered this from trying to troubleshoot this error (below) from a contributor of the diaper repo.
![Screen Shot 2020-07-25 at 12 18 14 PM](https://user-images.githubusercontent.com/11335191/88462496-56234600-ce71-11ea-989b-a7bf16a50f72.png)

By raising an error earlier via this PR, I get a slightly better error message:
![Screen Shot 2020-07-25 at 12 22 22 PM](https://user-images.githubusercontent.com/11335191/88462517-84a12100-ce71-11ea-8894-7341b770c743.png)

Ideally, this sort of error gracefully fails. But for now, I think this PR makes the error clearer and easier to pinpoint the source of the issue (aka in this case the id doesn't match any Partner in the partner db)

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Added a spec that covers this case.