### PR TITLE
Prevent hiding children, family, and family request list results due to pagination

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -10,7 +10,8 @@ class ChildrenController < ApplicationController
           .order(sort_column + ' ' + sort_direction),
       params[:filterrific]
     ) || return
-    @children = @filterrific.find.page(params[:page])
+
+    @children = @filterrific.find
 
     respond_to do |format|
       format.js

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -9,7 +9,8 @@ class FamiliesController < ApplicationController
           .order(sort_column + ' ' + sort_direction),
       params[:filterrific]
     ) || return
-    @families = @filterrific.find.page(params[:page])
+
+    @families = @filterrific.find
 
     respond_to do |format|
       format.js

--- a/app/controllers/family_requests_controller.rb
+++ b/app/controllers/family_requests_controller.rb
@@ -9,7 +9,7 @@ class FamilyRequestsController < ApplicationController
           .order(first_name: :asc),
       params[:filterrific]
     ) || return
-    @children = @filterrific.find.page(params[:page])
+    @children = @filterrific.find
   end
 
   def create


### PR DESCRIPTION
Resolves #395

### Description
Our partner users are getting confused because they are unable to scroll through all their children, family, or family request records. This was due to the addition of `.pagination` which forced the results to be limited to 25 records. Normally pagination would be great, but we are missing buttons to navigate between pagination pages and it seems to be a larger lift to change that behavior.

I think we should introduce pagination again when performance becomes an issue. However, for now I suggest we just remove it until we get to that point.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Login as a partner
2. Access the pages changed and ensure you are seeing all the records rather than just 25
