### PR TITLE
Render email instead of non existent name on User for dropdown button

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,7 @@
 
 <li class="nav-item dropdown">
   <a class="nav-link" data-toggle="dropdown" href="#">
-    <%= current_user.name %>
+    <%= current_user.email %>
   </a>
   <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
     <%= link_to edit_partner_path(current_partner), class:"dropdown-item" do %>


### PR DESCRIPTION
Resolves #403

### Description
Instead of rendering the nonexistent `name` on User records, this PR renders the email which does exist on User records.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### Screenshots
![Screen Shot 2020-08-27 at 7 40 23 AM](https://user-images.githubusercontent.com/11335191/91443411-ecfc6d00-e838-11ea-9ecc-c48d0f646221.png)

