### PR TITLE
Prevent error caused by family request without defined item for children.

### DIFF
--- a/app/controllers/family_requests_controller.rb
+++ b/app/controllers/family_requests_controller.rb
@@ -14,12 +14,13 @@ class FamilyRequestsController < ApplicationController
 
   def create
     verify_status_in_diaper_base
-    children = current_partner.children.active
+    children = current_partner.children.active.where.not(item_needed_diaperid: nil)
     children_grouped_by_diaperid = children.group_by(&:item_needed_diaperid)
     api_response = DiaperBankClient.send_family_request(
       children: children,
       partner: current_partner
     )
+
     if api_response
       flash[:notice] = "Request sent to diaper bank successfully"
       partner_request = PartnerRequest.new(

--- a/app/views/family_requests/_list.html.erb
+++ b/app/views/family_requests/_list.html.erb
@@ -18,17 +18,23 @@
         <%= child.first_name %> <%= child.last_name %>
       </td>
       <td>
-        <%= item_id_to_display_string_map[child.item_needed_diaperid] %>
+        <% if child.item_needed_diaperid %>
+          <%= item_id_to_display_string_map[child.item_needed_diaperid] %>
+        <% else %>
+          <%= "N/A" %>
+        <% end %>
       </td>
       <td>
         <div class="custom-control custom-switch">
-        <%= check_box_tag 'Active', child.active, child.active,
+          <% if child.item_needed_diaperid %>
+            <%= check_box_tag 'Active', child.active, child.active,
                               data: {url: child_active_path(child),
                                      remote: true, method: :post },
                               class: "custom-control-input",
                               id: "child-#{child.id}"
                               %>
-          <label class="custom-control-label" for="child-<%= child.id %>"></label>
+            <label class="custom-control-label" for="child-<%= child.id %>"></label>
+          <% end %>
         </div>
       </td>
     </tr>

--- a/spec/requests/family_requests_controller_spec.rb
+++ b/spec/requests/family_requests_controller_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe FamilyRequestsController, type: :request do
+  let(:partner) { create(:partner) }
+  let!(:family) { create(:family, partner_id: partner.id) }
+  let!(:children) { FactoryBot.create_list(:child, 3, family: family) }
+  let!(:user) { create(:user, partner: partner) }
+
+  before do
+    sign_in(user)
+  end
+
+  describe 'POST #create' do
+    before do
+      # Set one child as deactivated and the other as active but
+      # without a item_needed_diaperid
+      children[0].update(active: false)
+      children[1].update(item_needed_diaperid: nil)
+      allow(DiaperBankClient).to receive(:send_family_request)
+    end
+
+    it "should send a family request for only active children with a defined item needed" do
+      post family_requests_path
+
+      expect(DiaperBankClient).to have_received(:send_family_request).with(
+        children: partner.children.active.where.not(item_needed_diaperid: nil),
+        partner: partner
+      )
+    end
+  end
+
+end

--- a/spec/requests/family_requests_controller_spec.rb
+++ b/spec/requests/family_requests_controller_spec.rb
@@ -28,5 +28,4 @@ RSpec.describe FamilyRequestsController, type: :request do
       )
     end
   end
-
 end


### PR DESCRIPTION
### Description

This PR addresses a bug in which a 500 error occurs when submitting a family request that has a child without a defined item that they need. The way this PR achieves is it is by modifying the query to skip sending a payload with children w/o items in need. In addition, it includes a UI change to hide the active toggle if the item isn't defined.



### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Built a request spec for this :)

### Screenshots
![Screen Shot 2020-08-29 at 12 24 15 PM](https://user-images.githubusercontent.com/11335191/91645282-78c4f380-ea09-11ea-971c-d4791562aee8.png)

