### PR TITLE
WIP: Pass partner_id to request when getting available items

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :valid_items
   def valid_items
-    @valid_items ||= DiaperBankClient.get_available_items(current_partner.diaper_bank_id)
+    @valid_items ||= DiaperBankClient.get_available_items(current_partner.diaper_bank_id, current_partner.id)
   end
 
   helper_method :fetch_valid_item

--- a/app/services/diaper_bank_client.rb
+++ b/app/services/diaper_bank_client.rb
@@ -6,8 +6,10 @@ module DiaperBankClient
     ).body
   end
 
-  def self.get_available_items(diaper_bank_id)
-    response = diaper_get_request(routes.partner_requests(diaper_bank_id))
+  def self.get_available_items(diaper_bank_id, partner_id)
+    partner_request_uri = routes.partner_requests(diaper_bank_id)
+    partner_request_uri.query = "partner_id=#{partner_id}"
+    response = diaper_get_request(partner_request_uri)
     if response.code.to_i == 200
       JSON.parse(response.body)
     else


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/2059

### Description
Pass the partner_id to diaperbase so diaperbase can scope the items down by partner groups if applicable.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

TODO: need to add specs

### Screenshots

TODO: